### PR TITLE
Change the framework for unit testing from nose to pytest and bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose cython scikit-learn pytest
   - conda activate test-environment
-  - python setup.py install
+  - python setup.py develop
 
 script:
   - pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 
 env:
   global:
-    - TEST_DIR=/tmp/test_dir/
     - MODULE=pyrfm
 
 install:
@@ -28,11 +27,9 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose cython scikit-learn
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose cython scikit-learn pytest
   - conda activate test-environment
   - python setup.py install
 
 script:
-  - mkdir -p $TEST_DIR
-  - cd $TEST_DIR
-  - nosetests -v $MODULE
+  - pytest -v

--- a/pyrfm/kernels.py
+++ b/pyrfm/kernels.py
@@ -83,9 +83,9 @@ def anova(X, P, degree, dense_output=True):
         Ds += [D(X, P, t, dense_output) for t in range(2, degree+1)]
         anovas = [1., Ds[0]]
         for m in range(2, degree+1):
-            A = np.zeros((n1, n2))
-            sign = 1.
-            for t in range(1, m+1):
+            A = safe_np_elem_prod(anovas[m-1], Ds[0], dense_output)
+            sign = -1.
+            for t in range(2, m+1):
                 A += sign * safe_np_elem_prod(anovas[m-t], Ds[t-1],
                                               dense_output)
                 sign *= -1.

--- a/pyrfm/linear_model/tests/test_adagrad.py
+++ b/pyrfm/linear_model/tests/test_adagrad.py
@@ -9,7 +9,12 @@ from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.preprocessing import StandardScaler
 from .utils_linear_model import generate_target, generate_samples
 from scipy.sparse import csr_matrix
+import pytest
+from itertools import product
 
+
+loss_clf = ['squared_hinge', 'hinge', 'log']
+loss_reg = ['squared']
 
 # generate data
 n_samples = 500
@@ -20,197 +25,193 @@ X_train = X[:n_train]
 X_test = X[n_train:]
 
 
-def test_regressor_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        for loss in ['squared']:
-            # overfitting
-            clf = AdaGradRegressor(transformer, max_iter=300, warm_start=True,
-                                   verbose=False, fit_intercept=True, loss=loss,
-                                   alpha=0.0001, intercept_decay=1e-6,
-                                   random_state=0, tol=0, normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
-            assert_less_equal(l2, 0.01)
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    # overfitting
+    clf = AdaGradRegressor(transformer, max_iter=300, warm_start=True,
+                           verbose=False, fit_intercept=True, loss=loss,
+                           alpha=0.0001, intercept_decay=1e-6,
+                           random_state=0, tol=0, normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
+    assert_less_equal(l2, 0.01)
 
-            # underfitting
-            clf_under = AdaGradRegressor(transformer, max_iter=100, warm_start=True,
-                                         verbose=False, fit_intercept=True, loss=loss,
-                                         alpha=100000, random_state=0,
-                                         normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    # underfitting
+    clf_under = AdaGradRegressor(transformer, max_iter=100, warm_start=True,
+                                 verbose=False, fit_intercept=True, loss=loss,
+                                 alpha=100000, random_state=0,
+                                 normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                            np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = AdaGradRegressor(transformer, max_iter=100, warm_start=True,
-                                      verbose=False, fit_intercept=True,
-                                      loss=loss, alpha=1000, l1_ratio=0.9,
-                                      random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = AdaGradRegressor(transformer, max_iter=100, warm_start=True,
+                              verbose=False, fit_intercept=True,
+                              loss=loss, alpha=1000, l1_ratio=0.9,
+                              random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with sgd
-            sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
-                               learning_rate='constant', fit_intercept=True,
-                               random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
-            clf = AdaGradRegressor(transformer, max_iter=100, warm_start=True,
-                                   verbose=False, fit_intercept=True, loss=loss,
-                                   alpha=0.01, random_state=0, normalize=normalize,
-                                   )
+    # comparison with sgd
+    sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
+                       learning_rate='constant', fit_intercept=True,
+                       random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
+    clf = AdaGradRegressor(transformer, max_iter=100, warm_start=True,
+                           verbose=False, fit_intercept=True, loss=loss,
+                           alpha=0.01, random_state=0, normalize=normalize)
 
-            clf.fit(X_train, y_train)
-            test_l2 = np.mean((y_test - clf.predict(X_test))**2)
-            assert_less_equal(test_l2, test_l2_sgd)
+    clf.fit(X_train, y_train)
+    test_l2 = np.mean((y_test - clf.predict(X_test))**2)
+    assert_less_equal(test_l2, test_l2_sgd)
 
 
-def test_classifier_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        y_train = np.sign(y_train)
-        y_test = np.sign(y_test)
-        for loss in ['squared_hinge', 'log', 'hinge']:
-            # overfitting
-            clf = AdaGradClassifier(transformer, max_iter=500, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=0.00001, intercept_decay=1e-10,
-                                    random_state=0, tol=0, eta0=0.1,
-                                    normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            train_acc = clf.score(X_train[:100], y_train[:100])
-            assert_greater_equal(train_acc, 0.95)
-            # underfitting
-            clf_under = AdaGradClassifier(transformer, max_iter=100, warm_start=True,
-                                          verbose=False, fit_intercept=True,
-                                          loss=loss, alpha=10000,
-                                          random_state=0, normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    y_train = np.sign(y_train)
+    y_test = np.sign(y_test)
+    # overfitting
+    clf = AdaGradClassifier(transformer, max_iter=500, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=0.00001, intercept_decay=1e-10,
+                            random_state=0, tol=0, eta0=0.1,
+                            normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    train_acc = clf.score(X_train[:100], y_train[:100])
+    assert_greater_equal(train_acc, 0.95)
+    # underfitting
+    clf_under = AdaGradClassifier(transformer, max_iter=100, warm_start=True,
+                                  verbose=False, fit_intercept=True,
+                                  loss=loss, alpha=10000,
+                                  random_state=0, normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = AdaGradClassifier(transformer, max_iter=100, warm_start=True,
-                                       verbose=False, fit_intercept=True, loss=loss,
-                                       alpha=1000, l1_ratio=0.9,
-                                       random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = AdaGradClassifier(transformer, max_iter=100, warm_start=True,
+                               verbose=False, fit_intercept=True, loss=loss,
+                               alpha=1000, l1_ratio=0.9,
+                               random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with SGD
-            sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
-                                learning_rate='constant', fit_intercept=True,
-                                loss=loss, random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
-            clf = AdaGradClassifier(transformer, max_iter=100, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=0.01, random_state=0, normalize=normalize,
-                                    eta0=0.1)
+    # comparison with SGD
+    sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
+                        learning_rate='constant', fit_intercept=True,
+                        loss=loss, random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
+    clf = AdaGradClassifier(transformer, max_iter=100, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=0.01, random_state=0, normalize=normalize,
+                            eta0=0.1)
 
-            clf.fit(X_train, y_train)
-            test_acc = clf.score(X_test, y_test)
-            assert_greater_equal(test_acc, test_acc_sgd)
+    clf.fit(X_train, y_train)
+    test_acc = clf.score(X_test, y_test)
+    assert_greater_equal(test_acc, test_acc_sgd)
 
 
 def _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
-                    normalize=False, sparse=True):
-    for loss in ['squared']:
-        # fast solver and slow solver
-        clf_slow = AdaGradRegressor(transformer, max_iter=10, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=0.0001, random_state=0,
-                                    normalize=normalize, fast_solver=False)
-        clf_slow.fit(X_train, y_train)
+                    normalize=False, sparse=True, loss='squared'):
+    # fast solver and slow solver
+    clf_slow = AdaGradRegressor(transformer, max_iter=10, warm_start=True,
+                                verbose=False, fit_intercept=True, loss=loss,
+                                alpha=0.0001, random_state=0,
+                                normalize=normalize, fast_solver=False)
+    clf_slow.fit(X_train, y_train)
 
-        clf_fast = AdaGradRegressor(transformer, max_iter=10, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=0.0001, random_state=0,
-                                    normalize=normalize, fast_solver=True)
-        clf_fast.fit(X_train, y_train)
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = AdaGradRegressor(transformer, loss=loss, max_iter=10,
-                                         random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = AdaGradRegressor(transformer, loss=loss, max_iter=10,
-                                          random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = AdaGradRegressor(transformer, max_iter=10, warm_start=True,
+                                verbose=False, fit_intercept=True, loss=loss,
+                                alpha=0.0001, random_state=0,
+                                normalize=normalize, fast_solver=True)
+    clf_fast.fit(X_train, y_train)
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = AdaGradRegressor(transformer, loss=loss, max_iter=10,
+                                        random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = AdaGradRegressor(transformer, loss=loss, max_iter=10,
+                                        random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = AdaGradRegressor(transformer, max_iter=10, shuffle=False,
-                               random_state=0, tol=0, loss=loss,
-                               warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = AdaGradRegressor(transformer, max_iter=5, shuffle=False,
-                                    random_state=0, tol=0, loss=loss,
-                                    warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = AdaGradRegressor(transformer, max_iter=10, shuffle=False,
+                            random_state=0, tol=0, loss=loss,
+                            warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = AdaGradRegressor(transformer, max_iter=5, shuffle=False,
+                                random_state=0, tol=0, loss=loss,
+                                warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
 def _test_classifier(transformer, X_train, y_train, X_test, y_test, X_trans,
-                     normalize=False, sparse=True):
-    for loss in ['squared_hinge', 'log', 'hinge']:
-        # fast solver and slow solver
-        clf_slow = AdaGradClassifier(transformer, max_iter=10, warm_start=True,
-                                     verbose=False, fit_intercept=True, loss=loss,
-                                     random_state=0, normalize=normalize,
-                                     fast_solver=False)
-        clf_slow.fit(X_train[:20], y_train[:20])
+                     normalize=False, sparse=True, loss="squared_hinge"):
+    # fast solver and slow solver
+    clf_slow = AdaGradClassifier(transformer, max_iter=10, warm_start=True,
+                                    verbose=False, fit_intercept=True, loss=loss,
+                                    random_state=0, normalize=normalize,
+                                    fast_solver=False)
+    clf_slow.fit(X_train[:20], y_train[:20])
 
-        clf_fast = AdaGradClassifier(transformer, max_iter=10, warm_start=True,
-                                     verbose=False, fit_intercept=True, loss=loss,
-                                     random_state=0, normalize=normalize,
-                                     fast_solver=True)
-        clf_fast.fit(X_train[:20], y_train[:20])
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = AdaGradClassifier(transformer, loss=loss, max_iter=10,
-                                          random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = AdaGradClassifier(transformer, loss=loss, max_iter=10,
-                                           random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = AdaGradClassifier(transformer, max_iter=10, warm_start=True,
+                                    verbose=False, fit_intercept=True, loss=loss,
+                                    random_state=0, normalize=normalize,
+                                    fast_solver=True)
+    clf_fast.fit(X_train[:20], y_train[:20])
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = AdaGradClassifier(transformer, loss=loss, max_iter=10,
+                                        random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = AdaGradClassifier(transformer, loss=loss, max_iter=10,
+                                        random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = AdaGradClassifier(transformer, max_iter=10, shuffle=False,
-                                random_state=0, tol=0, loss=loss,
-                                warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = AdaGradClassifier(transformer, max_iter=5, shuffle=False,
-                                     random_state=0, tol=0, loss=loss,
-                                     warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = AdaGradClassifier(transformer, max_iter=10, shuffle=False,
+                            random_state=0, tol=0, loss=loss,
+                            warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = AdaGradClassifier(transformer, max_iter=5, shuffle=False,
+                                    random_state=0, tol=0, loss=loss,
+                                    warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
-def test_classifier_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -219,10 +220,12 @@ def test_classifier_ts():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                     np.sign(y_test), X_trans)
+                     np.sign(y_test), X_trans, normalize=normalize, 
+                     loss=loss)
 
 
-def test_regressor_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -230,118 +233,43 @@ def test_regressor_ts():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_clf, [2,3,4]))
+def test_classifier_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
+    _test_classifier(transformer, X_train, np.sign(y_train), X_test,
+                     np.sign(y_test), X_trans, normalize=normalize,
+                     loss=loss)
 
 
-def test_regressor_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_reg, [2, 3, 4]))
+def test_regressor_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                         np.sign(y_test), X_trans)
-
-
-def test_regressor_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(
-            transformer,
-            X_train,
-            np.sign(y_train),
-            X_test,
-            np.sign(y_test),
-            X_trans,
-            True)
-
-
-def test_regressor_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(
-            transformer,
-            X_train,
-            y_train,
-            X_test,
-            y_test,
-            X_trans,
-            True)
-
-
-def test_classifier_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -356,10 +284,13 @@ def test_classifier_rk_as():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -368,50 +299,12 @@ def test_regressor_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -425,10 +318,13 @@ def test_classifier_rm():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -436,48 +332,12 @@ def test_regressor_rm():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
@@ -491,59 +351,26 @@ def test_classifier_rf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rbf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
@@ -557,59 +384,26 @@ def test_classifier_rbf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rbf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rbf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rbf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -624,10 +418,13 @@ def test_classifier_skewed():
         X_test,
         np.sign(y_test),
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -642,50 +439,13 @@ def test_regressor_skewed():
         X_test,
         y_test,
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_classifier_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_regressor_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_classifier_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -699,10 +459,13 @@ def test_classifier_additive():
         np.sign(y_train),
         np.abs(X_test),
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -716,42 +479,6 @@ def test_regressor_additive():
         y_train,
         np.abs(X_test),
         y_test,
-        X_trans)
-
-
-def test_classifier_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        np.abs(X_train),
-        np.sign(y_train),
-        np.abs(X_test),
-        np.sign(y_test),
         X_trans,
-        True)
-
-
-def test_regressor_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        np.abs(X_train),
-        y_train,
-        np.abs(X_test),
-        y_test,
-        X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)

--- a/pyrfm/linear_model/tests/test_adam.py
+++ b/pyrfm/linear_model/tests/test_adam.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from sklearn.utils.testing import (assert_greater_equal, assert_almost_equal,
                                    assert_less_equal)
 from pyrfm import (TensorSketch, RandomKernel, RandomMaclaurin, RandomFourier,
@@ -9,7 +8,12 @@ from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.preprocessing import StandardScaler
 from .utils_linear_model import generate_target, generate_samples
 from scipy.sparse import csr_matrix
+import pytest
+from itertools import product
 
+
+loss_reg = ['squared']
+loss_clf = ['squared_hinge', 'log', 'hinge']
 
 # generate data
 n_samples = 500
@@ -20,195 +24,191 @@ X_train = X[:n_train]
 X_test = X[n_train:]
 
 
-def test_regressor_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        for loss in ['squared']:
-            # overfitting
-            clf = AdamRegressor(transformer, max_iter=300, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.0001, intercept_decay=1e-6,
-                                random_state=0, tol=0, normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
-            assert_less_equal(l2, 0.01)
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    # overfitting
+    clf = AdamRegressor(transformer, max_iter=300, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.0001, intercept_decay=1e-6,
+                        random_state=0, tol=0, normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
+    assert_less_equal(l2, 0.01)
 
-            # underfitting
-            clf_under = AdamRegressor(transformer, max_iter=100, warm_start=True,
-                                      verbose=False, fit_intercept=True, loss=loss,
-                                      alpha=100000, random_state=0,
-                                      normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    # underfitting
+    clf_under = AdamRegressor(transformer, max_iter=100, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              alpha=100000, random_state=0,
+                              normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = AdamRegressor(transformer, max_iter=100, warm_start=True,
-                                   verbose=False, fit_intercept=True,
-                                   loss=loss, alpha=1000, l1_ratio=0.9,
-                                   random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = AdamRegressor(transformer, max_iter=100, warm_start=True,
+                           verbose=False, fit_intercept=True,
+                           loss=loss, alpha=1000, l1_ratio=0.9,
+                           random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with sgd
-            sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
-                               learning_rate='constant', fit_intercept=True,
-                               random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
-            clf = AdamRegressor(transformer, max_iter=100, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.01, random_state=0, normalize=normalize,
-                                )
+    # comparison with sgd
+    sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
+                       learning_rate='constant', fit_intercept=True,
+                       random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
+    clf = AdamRegressor(transformer, max_iter=100, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.01, random_state=0, normalize=normalize)
 
-            clf.fit(X_train, y_train)
-            test_l2 = np.mean((y_test - clf.predict(X_test))**2)
-            assert_less_equal(test_l2, test_l2_sgd)
+    clf.fit(X_train, y_train)
+    test_l2 = np.mean((y_test - clf.predict(X_test))**2)
+    assert_less_equal(test_l2, test_l2_sgd)
 
 
-def test_classifier_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        y_train = np.sign(y_train)
-        y_test = np.sign(y_test)
-        for loss in ['squared_hinge', 'log', 'hinge']:
-            # overfitting
-            clf = AdamClassifier(transformer, max_iter=500, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.00001, intercept_decay=1e-10,
-                                 random_state=0, tol=0, normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            train_acc = clf.score(X_train[:100], y_train[:100])
-            assert_greater_equal(train_acc, 0.95)
-            # underfitting
-            clf_under = AdamClassifier(transformer, max_iter=100, warm_start=True,
-                                       verbose=False, fit_intercept=True,
-                                       loss=loss, alpha=10000,
-                                       random_state=0, normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    y_train = np.sign(y_train)
+    y_test = np.sign(y_test)
+    # overfitting
+    clf = AdamClassifier(transformer, max_iter=500, warm_start=True,
+                         verbose=False, fit_intercept=True, loss=loss,
+                         alpha=0.00001, intercept_decay=1e-10,
+                         random_state=0, tol=0, normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    train_acc = clf.score(X_train[:100], y_train[:100])
+    assert_greater_equal(train_acc, 0.95)
+    # underfitting
+    clf_under = AdamClassifier(transformer, max_iter=100, warm_start=True,
+                               verbose=False, fit_intercept=True,
+                               loss=loss, alpha=10000,
+                               random_state=0, normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                            np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = AdamClassifier(transformer, max_iter=100, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=1000, l1_ratio=0.9,
-                                    random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = AdamClassifier(transformer, max_iter=100, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=1000, l1_ratio=0.9,
+                            random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with SGD
-            sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
-                                learning_rate='constant', fit_intercept=True,
-                                loss=loss, random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
-            clf = AdamClassifier(transformer, max_iter=100, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.01, random_state=0, normalize=normalize)
+    # comparison with SGD
+    sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
+                        learning_rate='constant', fit_intercept=True,
+                        loss=loss, random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
+    clf = AdamClassifier(transformer, max_iter=100, warm_start=True,
+                         verbose=False, fit_intercept=True, loss=loss,
+                         alpha=0.01, random_state=0, normalize=normalize)
 
-            clf.fit(X_train, y_train)
-            test_acc = clf.score(X_test, y_test)
-            assert_greater_equal(test_acc, test_acc_sgd)
+    clf.fit(X_train, y_train)
+    test_acc = clf.score(X_test, y_test)
+    assert_greater_equal(test_acc, test_acc_sgd)
 
 
 def _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
-                    normalize=False, sparse=True):
-    for loss in ['squared']:
-        # fast solver and slow solver
-        clf_slow = AdamRegressor(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.0001, random_state=0,
-                                 normalize=normalize, fast_solver=False)
-        clf_slow.fit(X_train, y_train)
+                    normalize=False, sparse=True, loss='squared'):
+    # fast solver and slow solver
+    clf_slow = AdamRegressor(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=0.0001, random_state=0,
+                             normalize=normalize, fast_solver=False)
+    clf_slow.fit(X_train, y_train)
 
-        clf_fast = AdamRegressor(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.0001, random_state=0,
-                                 normalize=normalize, fast_solver=True)
-        clf_fast.fit(X_train, y_train)
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = AdamRegressor(transformer, loss=loss, max_iter=10,
-                                      random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = AdamRegressor(transformer, loss=loss, max_iter=10,
-                                       random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = AdamRegressor(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=0.0001, random_state=0,
+                             normalize=normalize, fast_solver=True)
+    clf_fast.fit(X_train, y_train)
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = AdamRegressor(transformer, loss=loss, max_iter=10,
+                                  random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = AdamRegressor(transformer, loss=loss, max_iter=10,
+                                    random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = AdamRegressor(transformer, max_iter=10, shuffle=False,
-                            random_state=0, tol=0, loss=loss,
-                            warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = AdamRegressor(transformer, max_iter=5, shuffle=False,
-                                 random_state=0, tol=0, loss=loss,
-                                 warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = AdamRegressor(transformer, max_iter=10, shuffle=False,
+                        random_state=0, tol=0, loss=loss,
+                        warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = AdamRegressor(transformer, max_iter=5, shuffle=False,
+                             random_state=0, tol=0, loss=loss,
+                             warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
 def _test_classifier(transformer, X_train, y_train, X_test, y_test, X_trans,
-                     normalize=False, sparse=True):
-    for loss in ['squared_hinge', 'log', 'hinge']:
-        # fast solver and slow solver
-        clf_slow = AdamClassifier(transformer, max_iter=10, warm_start=True,
-                                  verbose=False, fit_intercept=True, loss=loss,
-                                  random_state=0, normalize=normalize,
-                                  fast_solver=False)
-        clf_slow.fit(X_train[:20], y_train[:20])
+                     normalize=False, sparse=True, loss='squared_hinge'):
+    # fast solver and slow solver
+    clf_slow = AdamClassifier(transformer, max_iter=10, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              random_state=0, normalize=normalize,
+                              fast_solver=False)
+    clf_slow.fit(X_train[:20], y_train[:20])
 
-        clf_fast = AdamClassifier(transformer, max_iter=10, warm_start=True,
-                                  verbose=False, fit_intercept=True, loss=loss,
-                                  random_state=0, normalize=normalize,
-                                  fast_solver=True)
-        clf_fast.fit(X_train[:20], y_train[:20])
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = AdamClassifier(transformer, loss=loss, max_iter=10,
-                                       random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = AdamClassifier(transformer, loss=loss, max_iter=10,
-                                        random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = AdamClassifier(transformer, max_iter=10, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              random_state=0, normalize=normalize,
+                              fast_solver=True)
+    clf_fast.fit(X_train[:20], y_train[:20])
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = AdamClassifier(transformer, loss=loss, max_iter=10,
+                                   random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = AdamClassifier(transformer, loss=loss, max_iter=10,
+                                    random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = AdamClassifier(transformer, max_iter=10, shuffle=False,
-                             random_state=0, tol=0, loss=loss,
-                             warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = AdamClassifier(transformer, max_iter=5, shuffle=False,
-                                  random_state=0, tol=0, loss=loss,
-                                  warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = AdamClassifier(transformer, max_iter=10, shuffle=False,
+                         random_state=0, tol=0, loss=loss,
+                         warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = AdamClassifier(transformer, max_iter=5, shuffle=False,
+                              random_state=0, tol=0, loss=loss,
+                              warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
-def test_classifier_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -217,10 +217,12 @@ def test_classifier_ts():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                     np.sign(y_test), X_trans)
+                     np.sign(y_test), X_trans, normalize=normalize, 
+                     loss=loss)
 
 
-def test_regressor_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -228,118 +230,43 @@ def test_regressor_ts():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_clf, [2,3,4]))
+def test_classifier_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
+    _test_classifier(transformer, X_train, np.sign(y_train), X_test,
+                     np.sign(y_test), X_trans, normalize=normalize,
+                     loss=loss)
 
 
-def test_regressor_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_reg, [2, 3, 4]))
+def test_regressor_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                         np.sign(y_test), X_trans)
-
-
-def test_regressor_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(
-            transformer,
-            X_train,
-            np.sign(y_train),
-            X_test,
-            np.sign(y_test),
-            X_trans,
-            True)
-
-
-def test_regressor_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(
-            transformer,
-            X_train,
-            y_train,
-            X_test,
-            y_test,
-            X_trans,
-            True)
-
-
-def test_classifier_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -354,10 +281,13 @@ def test_classifier_rk_as():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -366,50 +296,12 @@ def test_regressor_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -423,10 +315,13 @@ def test_classifier_rm():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -434,48 +329,12 @@ def test_regressor_rm():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
@@ -489,59 +348,26 @@ def test_classifier_rf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rbf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
@@ -555,59 +381,26 @@ def test_classifier_rbf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rbf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rbf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rbf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -622,10 +415,13 @@ def test_classifier_skewed():
         X_test,
         np.sign(y_test),
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -640,50 +436,13 @@ def test_regressor_skewed():
         X_test,
         y_test,
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_classifier_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_regressor_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_classifier_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -697,10 +456,13 @@ def test_classifier_additive():
         np.sign(y_train),
         np.abs(X_test),
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -714,42 +476,6 @@ def test_regressor_additive():
         y_train,
         np.abs(X_test),
         y_test,
-        X_trans)
-
-
-def test_classifier_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        np.abs(X_train),
-        np.sign(y_train),
-        np.abs(X_test),
-        np.sign(y_test),
         X_trans,
-        True)
-
-
-def test_regressor_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        np.abs(X_train),
-        y_train,
-        np.abs(X_test),
-        y_test,
-        X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)

--- a/pyrfm/linear_model/tests/test_saga.py
+++ b/pyrfm/linear_model/tests/test_saga.py
@@ -9,7 +9,12 @@ from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.preprocessing import StandardScaler
 from .utils_linear_model import generate_target, generate_samples
 from scipy.sparse import csr_matrix
+import pytest
+from itertools import product
 
+
+loss_reg = ['squared']
+loss_clf = ['squared_hinge', 'log', 'hinge']
 
 # generate data
 n_samples = 500
@@ -20,199 +25,196 @@ X_train = X[:n_train]
 X_test = X[n_train:]
 
 
-def test_regressor_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        for loss in ['squared']:
-            # overfitting
-            clf = SAGARegressor(transformer, max_iter=300, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.0001, intercept_decay=1e-6,
-                                random_state=0, tol=0, normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
-            assert_less_equal(l2, 0.01)
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    # overfitting
+    clf = SAGARegressor(transformer, max_iter=300, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.0001, intercept_decay=1e-6,
+                        random_state=0, tol=0, normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
+    assert_less_equal(l2, 0.01)
 
-            # underfitting
-            clf_under = SAGARegressor(transformer, max_iter=100, warm_start=True,
-                                      verbose=False, fit_intercept=True, loss=loss,
-                                      alpha=100000, random_state=0,
-                                      normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    # underfitting
+    clf_under = SAGARegressor(transformer, max_iter=100, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              alpha=100000, random_state=0,
+                              normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = SAGARegressor(transformer, max_iter=100, warm_start=True,
-                                   verbose=False, fit_intercept=True,
-                                   loss=loss, alpha=1000, l1_ratio=0.9,
-                                   random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = SAGARegressor(transformer, max_iter=100, warm_start=True,
+                           verbose=False, fit_intercept=True,
+                           loss=loss, alpha=1000, l1_ratio=0.9,
+                           random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with sgd
-            sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
-                               learning_rate='constant', fit_intercept=True,
-                               random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
-            clf = SAGARegressor(transformer, max_iter=100, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.01, random_state=0, normalize=normalize,
-                                )
+    # comparison with sgd
+    sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
+                       learning_rate='constant', fit_intercept=True,
+                       random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
+    clf = SAGARegressor(transformer, max_iter=100, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.01, random_state=0, normalize=normalize,
+                        )
 
-            clf.fit(X_train, y_train)
-            test_l2 = np.mean((y_test - clf.predict(X_test))**2)
-            assert_less_equal(test_l2, test_l2_sgd)
+    clf.fit(X_train, y_train)
+    test_l2 = np.mean((y_test - clf.predict(X_test))**2)
+    assert_less_equal(test_l2, test_l2_sgd)
 
 
-def test_classifier_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        y_train = np.sign(y_train)
-        y_test = np.sign(y_test)
-        for loss in ['squared_hinge', 'log', 'hinge']:
-            # overfitting
-            clf = SAGAClassifier(transformer, max_iter=500, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.00001, intercept_decay=1e-10,
-                                 random_state=0, tol=0, eta0=0.01,
-                                 normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            train_acc = clf.score(X_train[:100], y_train[:100])
-            assert_greater_equal(train_acc, 0.95)
-            # underfitting
-            clf_under = SAGAClassifier(transformer, max_iter=100, warm_start=True,
-                                       verbose=False, fit_intercept=True,
-                                       loss=loss, alpha=10000,
-                                       random_state=0, normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    y_train = np.sign(y_train)
+    y_test = np.sign(y_test)
+    # overfitting
+    clf = SAGAClassifier(transformer, max_iter=500, warm_start=True,
+                         verbose=False, fit_intercept=True, loss=loss,
+                         alpha=0.00001, intercept_decay=1e-10,
+                         random_state=0, tol=0, eta0=0.01,
+                         normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    train_acc = clf.score(X_train[:100], y_train[:100])
+    assert_greater_equal(train_acc, 0.95)
+    # underfitting
+    clf_under = SAGAClassifier(transformer, max_iter=100, warm_start=True,
+                               verbose=False, fit_intercept=True,
+                               loss=loss, alpha=10000,
+                               random_state=0, normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = SAGAClassifier(transformer, max_iter=100, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=1000, l1_ratio=0.9,
-                                    random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = SAGAClassifier(transformer, max_iter=100, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=1000, l1_ratio=0.9,
+                            random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with SGD
-            sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
-                                learning_rate='constant', fit_intercept=True,
-                                loss=loss, random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
-            clf = SAGAClassifier(transformer, max_iter=100, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.01, random_state=0, normalize=normalize,
-                                 eta0=0.1)
+    # comparison with SGD
+    sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
+                        learning_rate='constant', fit_intercept=True,
+                        loss=loss, random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
+    clf = SAGAClassifier(transformer, max_iter=100, warm_start=True,
+                         verbose=False, fit_intercept=True, loss=loss,
+                         alpha=0.01, random_state=0, normalize=normalize,
+                         eta0=0.1)
 
-            clf.fit(X_train, y_train)
-            test_acc = clf.score(X_test, y_test)
-            assert_greater_equal(test_acc, test_acc_sgd)
+    clf.fit(X_train, y_train)
+    test_acc = clf.score(X_test, y_test)
+    assert_greater_equal(test_acc, test_acc_sgd)
 
 
 def _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
-                    normalize=False, sparse=True):
-    for loss in ['squared']:
-        # fast solver and slow solver
-        clf_slow = SAGARegressor(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.0001, random_state=0,
-                                 normalize=normalize, fast_solver=False)
-        clf_slow.fit(X_train, y_train)
+                    normalize=False, sparse=True, loss='squared'):
+    # fast solver and slow solver
+    clf_slow = SAGARegressor(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=0.0001, random_state=0,
+                             normalize=normalize, fast_solver=False)
+    clf_slow.fit(X_train, y_train)
 
-        clf_fast = SAGARegressor(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.0001, random_state=0,
-                                 normalize=normalize, fast_solver=True)
-        clf_fast.fit(X_train, y_train)
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = SAGARegressor(transformer, loss=loss, max_iter=10,
-                                      random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = SAGARegressor(transformer, loss=loss, max_iter=10,
-                                       random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = SAGARegressor(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=0.0001, random_state=0,
+                             normalize=normalize, fast_solver=True)
+    clf_fast.fit(X_train, y_train)
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = SAGARegressor(transformer, loss=loss, max_iter=10,
+                                  random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = SAGARegressor(transformer, loss=loss, max_iter=10,
+                                   random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = SAGARegressor(transformer, max_iter=10, shuffle=False,
-                            random_state=0, tol=0, loss=loss,
-                            warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = SAGARegressor(transformer, max_iter=5, shuffle=False,
-                                 random_state=0, tol=0, loss=loss,
-                                 warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.dloss_, clf_warm.dloss_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = SAGARegressor(transformer, max_iter=10, shuffle=False,
+                        random_state=0, tol=0, loss=loss,
+                        warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = SAGARegressor(transformer, max_iter=5, shuffle=False,
+                             random_state=0, tol=0, loss=loss,
+                             warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.dloss_, clf_warm.dloss_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
 def _test_classifier(transformer, X_train, y_train, X_test, y_test, X_trans,
-                     normalize=False, sparse=True):
-    for loss in ['squared_hinge', 'log', 'hinge']:
-        # fast solver and slow solver
-        clf_slow = SAGAClassifier(transformer, max_iter=10, warm_start=True,
-                                  verbose=False, fit_intercept=True, loss=loss,
-                                  random_state=0, normalize=normalize,
-                                  fast_solver=False)
-        clf_slow.fit(X_train[:20], y_train[:20])
+                     normalize=False, sparse=True, loss='squared_hinge'):
+    # fast solver and slow solver
+    clf_slow = SAGAClassifier(transformer, max_iter=10, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              random_state=0, normalize=normalize,
+                              fast_solver=False)
+    clf_slow.fit(X_train[:20], y_train[:20])
 
-        clf_fast = SAGAClassifier(transformer, max_iter=10, warm_start=True,
-                                  verbose=False, fit_intercept=True, loss=loss,
-                                  random_state=0, normalize=normalize,
-                                  fast_solver=True)
-        clf_fast.fit(X_train[:20], y_train[:20])
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = SAGAClassifier(transformer, loss=loss, max_iter=10,
-                                       random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = SAGAClassifier(transformer, loss=loss, max_iter=10,
-                                        random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = SAGAClassifier(transformer, max_iter=10, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              random_state=0, normalize=normalize,
+                              fast_solver=True)
+    clf_fast.fit(X_train[:20], y_train[:20])
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = SAGAClassifier(transformer, loss=loss, max_iter=10,
+                                   random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = SAGAClassifier(transformer, loss=loss, max_iter=10,
+                                    random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = SAGAClassifier(transformer, max_iter=10, shuffle=False,
-                             random_state=0, tol=0, loss=loss,
-                             warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = SAGAClassifier(transformer, max_iter=5, shuffle=False,
-                                  random_state=0, tol=0, loss=loss,
-                                  warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.dloss_, clf_warm.dloss_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = SAGAClassifier(transformer, max_iter=10, shuffle=False,
+                         random_state=0, tol=0, loss=loss,
+                         warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = SAGAClassifier(transformer, max_iter=5, shuffle=False,
+                              random_state=0, tol=0, loss=loss,
+                              warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.dloss_, clf_warm.dloss_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
-def test_classifier_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -221,10 +223,12 @@ def test_classifier_ts():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                     np.sign(y_test), X_trans)
+                     np.sign(y_test), X_trans, normalize=normalize, 
+                     loss=loss)
 
 
-def test_regressor_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -232,118 +236,43 @@ def test_regressor_ts():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_clf, [2,3,4]))
+def test_classifier_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
+    _test_classifier(transformer, X_train, np.sign(y_train), X_test,
+                     np.sign(y_test), X_trans, normalize=normalize,
+                     loss=loss)
 
 
-def test_regressor_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_reg, [2, 3, 4]))
+def test_regressor_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                         np.sign(y_test), X_trans)
-
-
-def test_regressor_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(
-            transformer,
-            X_train,
-            np.sign(y_train),
-            X_test,
-            np.sign(y_test),
-            X_trans,
-            True)
-
-
-def test_regressor_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(
-            transformer,
-            X_train,
-            y_train,
-            X_test,
-            y_test,
-            X_trans,
-            True)
-
-
-def test_classifier_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -358,10 +287,13 @@ def test_classifier_rk_as():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -370,50 +302,12 @@ def test_regressor_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -427,10 +321,13 @@ def test_classifier_rm():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -438,48 +335,12 @@ def test_regressor_rm():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
@@ -493,59 +354,26 @@ def test_classifier_rf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rbf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
@@ -559,59 +387,26 @@ def test_classifier_rbf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rbf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rbf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rbf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -626,10 +421,13 @@ def test_classifier_skewed():
         X_test,
         np.sign(y_test),
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -644,50 +442,13 @@ def test_regressor_skewed():
         X_test,
         y_test,
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_classifier_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_regressor_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_classifier_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -701,10 +462,13 @@ def test_classifier_additive():
         np.sign(y_train),
         np.abs(X_test),
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -718,42 +482,6 @@ def test_regressor_additive():
         y_train,
         np.abs(X_test),
         y_test,
-        X_trans)
-
-
-def test_classifier_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        np.abs(X_train),
-        np.sign(y_train),
-        np.abs(X_test),
-        np.sign(y_test),
         X_trans,
-        True)
-
-
-def test_regressor_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        np.abs(X_train),
-        y_train,
-        np.abs(X_test),
-        y_test,
-        X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)

--- a/pyrfm/linear_model/tests/test_sdca.py
+++ b/pyrfm/linear_model/tests/test_sdca.py
@@ -9,7 +9,12 @@ from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.preprocessing import StandardScaler
 from .utils_linear_model import generate_target, generate_samples
 from scipy.sparse import csr_matrix
+import pytest
+from itertools import product
 
+
+loss_reg = ['squared']
+loss_clf = ['squared_hinge', 'log', 'hinge']
 
 # generate data
 n_samples = 500
@@ -20,197 +25,194 @@ X_train = X[:n_train]
 X_test = X[n_train:]
 
 
-def test_regressor_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        for loss in ['squared']:
-            # overfitting
-            clf = SDCARegressor(transformer, max_iter=300, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.0001, intercept_decay=1e-6,
-                                random_state=0, tol=0, normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
-            assert_less_equal(l2, 0.01)
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    # overfitting
+    clf = SDCARegressor(transformer, max_iter=300, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.0001, intercept_decay=1e-6,
+                        random_state=0, tol=0, normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
+    assert_less_equal(l2, 0.01)
 
-            # underfitting
-            clf_under = SDCARegressor(transformer, max_iter=100, warm_start=True,
-                                      verbose=False, fit_intercept=True, loss=loss,
-                                      alpha=100000, random_state=0,
-                                      normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    # underfitting
+    clf_under = SDCARegressor(transformer, max_iter=100, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              alpha=100000, random_state=0,
+                              normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = SDCARegressor(transformer, max_iter=100, warm_start=True,
-                                   verbose=False, fit_intercept=True,
-                                   loss=loss, alpha=1000, l1_ratio=0.9,
-                                   random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = SDCARegressor(transformer, max_iter=100, warm_start=True,
+                           verbose=False, fit_intercept=True,
+                           loss=loss, alpha=1000, l1_ratio=0.9,
+                           random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with sgd
-            sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
-                               learning_rate='constant', fit_intercept=True,
-                               random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
-            clf = SDCARegressor(transformer, max_iter=100, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.01, random_state=0, normalize=normalize,
-                                )
+    # comparison with sgd
+    sgd = SGDRegressor(alpha=0.01, max_iter=100, eta0=1,
+                       learning_rate='constant', fit_intercept=True,
+                       random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_l2_sgd = np.mean((y_test - sgd.predict(X_trans[n_train:]))**2)
+    clf = SDCARegressor(transformer, max_iter=100, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.01, random_state=0, normalize=normalize,
+                        )
 
-            clf.fit(X_train, y_train)
-            test_l2 = np.mean((y_test - clf.predict(X_test))**2)
-            assert_less_equal(test_l2, test_l2_sgd)
+    clf.fit(X_train, y_train)
+    test_l2 = np.mean((y_test - clf.predict(X_test))**2)
+    assert_less_equal(test_l2, test_l2_sgd)
 
 
-def test_classifier_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        y_train = np.sign(y_train)
-        y_test = np.sign(y_test)
-        for loss in ['squared_hinge', 'log', 'hinge']:
-            # overfitting
-            clf = SDCAClassifier(transformer, max_iter=500, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.00001, intercept_decay=1e-10,
-                                 random_state=0, tol=0,
-                                 normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            train_acc = clf.score(X_train[:100], y_train[:100])
-            assert_greater_equal(train_acc, 0.95)
-            # underfitting
-            clf_under = SDCAClassifier(transformer, max_iter=100, warm_start=True,
-                                       verbose=False, fit_intercept=True,
-                                       loss=loss, alpha=10000,
-                                       random_state=0, normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    y_train = np.sign(y_train)
+    y_test = np.sign(y_test)
+    # overfitting
+    clf = SDCAClassifier(transformer, max_iter=500, warm_start=True,
+                         verbose=False, fit_intercept=True, loss=loss,
+                         alpha=0.00001, intercept_decay=1e-10,
+                         random_state=0, tol=0,
+                         normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    train_acc = clf.score(X_train[:100], y_train[:100])
+    assert_greater_equal(train_acc, 0.95)
+    # underfitting
+    clf_under = SDCAClassifier(transformer, max_iter=100, warm_start=True,
+                               verbose=False, fit_intercept=True,
+                               loss=loss, alpha=10000,
+                               random_state=0, normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = SDCAClassifier(transformer, max_iter=100, warm_start=True,
-                                    verbose=False, fit_intercept=True, loss=loss,
-                                    alpha=1000, l1_ratio=0.9,
-                                    random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = SDCAClassifier(transformer, max_iter=100, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=1000, l1_ratio=0.9,
+                            random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
-            # comparison with SGD
-            sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
-                                learning_rate='constant', fit_intercept=True,
-                                loss=loss, random_state=0)
-            sgd.fit(X_trans[:n_train], y_train)
-            test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
-            clf = SDCAClassifier(transformer, max_iter=100, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.01, random_state=0, normalize=normalize,
-                                 )
+    # comparison with SGD
+    sgd = SGDClassifier(alpha=0.01, max_iter=100, eta0=1,
+                        learning_rate='constant', fit_intercept=True,
+                        loss=loss, random_state=0)
+    sgd.fit(X_trans[:n_train], y_train)
+    test_acc_sgd = sgd.score(X_trans[n_train:], y_test)
+    clf = SDCAClassifier(transformer, max_iter=100, warm_start=True,
+                         verbose=False, fit_intercept=True, loss=loss,
+                         alpha=0.01, random_state=0, normalize=normalize,
+                         )
 
-            clf.fit(X_train, y_train)
-            test_acc = clf.score(X_test, y_test)
-            assert_greater_equal(test_acc, test_acc_sgd)
+    clf.fit(X_train, y_train)
+    test_acc = clf.score(X_test, y_test)
+    assert_greater_equal(test_acc, test_acc_sgd)
 
 
 def _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
-                    normalize=False, sparse=True):
-    for loss in ['squared']:
-        # fast solver and slow solver
-        clf_slow = SDCARegressor(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.0001, random_state=0,
-                                 normalize=normalize, fast_solver=False)
-        clf_slow.fit(X_train, y_train)
+                    normalize=False, sparse=True, loss='squared'):
+    # fast solver and slow solver
+    clf_slow = SDCARegressor(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=0.0001, random_state=0,
+                             normalize=normalize, fast_solver=False)
+    clf_slow.fit(X_train, y_train)
 
-        clf_fast = SDCARegressor(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=0.0001, random_state=0,
-                                 normalize=normalize, fast_solver=True)
-        clf_fast.fit(X_train, y_train)
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = SDCARegressor(transformer, loss=loss, max_iter=10,
-                                      random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = SDCARegressor(transformer, loss=loss, max_iter=10,
-                                       random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = SDCARegressor(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=0.0001, random_state=0,
+                             normalize=normalize, fast_solver=True)
+    clf_fast.fit(X_train, y_train)
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = SDCARegressor(transformer, loss=loss, max_iter=10,
+                                  random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = SDCARegressor(transformer, loss=loss, max_iter=10,
+                                   random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = SDCARegressor(transformer, max_iter=10, shuffle=False,
-                            random_state=0, tol=0, loss=loss,
-                            warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = SDCARegressor(transformer, max_iter=5, shuffle=False,
-                                 random_state=0, tol=0, loss=loss,
-                                 warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = SDCARegressor(transformer, max_iter=10, shuffle=False,
+                        random_state=0, tol=0, loss=loss,
+                        warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = SDCARegressor(transformer, max_iter=5, shuffle=False,
+                             random_state=0, tol=0, loss=loss,
+                             warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
 def _test_classifier(transformer, X_train, y_train, X_test, y_test, X_trans,
-                     normalize=False, sparse=True):
-    for loss in ['squared_hinge', 'log', 'hinge']:
-        # fast solver and slow solver
-        clf_slow = SDCAClassifier(transformer, max_iter=10, warm_start=True,
-                                  verbose=False, fit_intercept=True, loss=loss,
-                                  random_state=0, normalize=normalize,
-                                  fast_solver=False)
-        clf_slow.fit(X_train[:20], y_train[:20])
+                     normalize=False, sparse=True, loss='squared_hinge'):
+    # fast solver and slow solver
+    clf_slow = SDCAClassifier(transformer, max_iter=10, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              random_state=0, normalize=normalize,
+                              fast_solver=False)
+    clf_slow.fit(X_train[:20], y_train[:20])
 
-        clf_fast = SDCAClassifier(transformer, max_iter=10, warm_start=True,
-                                  verbose=False, fit_intercept=True, loss=loss,
-                                  random_state=0, normalize=normalize,
-                                  fast_solver=True)
-        clf_fast.fit(X_train[:20], y_train[:20])
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = SDCAClassifier(transformer, loss=loss, max_iter=10,
-                                       random_state=0, verbose=False)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = SDCAClassifier(transformer, loss=loss, max_iter=10,
-                                        random_state=0, verbose=False)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = SDCAClassifier(transformer, max_iter=10, warm_start=True,
+                              verbose=False, fit_intercept=True, loss=loss,
+                              random_state=0, normalize=normalize,
+                              fast_solver=True)
+    clf_fast.fit(X_train[:20], y_train[:20])
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = SDCAClassifier(transformer, loss=loss, max_iter=10,
+                                   random_state=0, verbose=False)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = SDCAClassifier(transformer, loss=loss, max_iter=10,
+                                    random_state=0, verbose=False)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = SDCAClassifier(transformer, max_iter=10, shuffle=False,
-                             random_state=0, tol=0, loss=loss,
-                             warm_start=False, verbose=False)
-        clf.fit(X_train, y_train)
-        clf_warm = SDCAClassifier(transformer, max_iter=5, shuffle=False,
-                                  random_state=0, tol=0, loss=loss,
-                                  warm_start=True, verbose=False)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = SDCAClassifier(transformer, max_iter=10, shuffle=False,
+                         random_state=0, tol=0, loss=loss,
+                         warm_start=False, verbose=False)
+    clf.fit(X_train, y_train)
+    clf_warm = SDCAClassifier(transformer, max_iter=5, shuffle=False,
+                              random_state=0, tol=0, loss=loss,
+                              warm_start=True, verbose=False)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
-def test_classifier_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -219,10 +221,12 @@ def test_classifier_ts():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                     np.sign(y_test), X_trans)
+                     np.sign(y_test), X_trans, normalize=normalize, 
+                     loss=loss)
 
 
-def test_regressor_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -230,118 +234,43 @@ def test_regressor_ts():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_clf, [2,3,4]))
+def test_classifier_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
+    _test_classifier(transformer, X_train, np.sign(y_train), X_test,
+                     np.sign(y_test), X_trans, normalize=normalize,
+                     loss=loss)
 
 
-def test_regressor_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_reg, [2, 3, 4]))
+def test_regressor_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                         np.sign(y_test), X_trans)
-
-
-def test_regressor_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(
-            transformer,
-            X_train,
-            np.sign(y_train),
-            X_test,
-            np.sign(y_test),
-            X_trans,
-            True)
-
-
-def test_regressor_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(
-            transformer,
-            X_train,
-            y_train,
-            X_test,
-            y_test,
-            X_trans,
-            True)
-
-
-def test_classifier_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -356,10 +285,13 @@ def test_classifier_rk_as():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -368,50 +300,12 @@ def test_regressor_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -425,10 +319,13 @@ def test_classifier_rm():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -436,48 +333,12 @@ def test_regressor_rm():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
@@ -491,59 +352,26 @@ def test_classifier_rf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rbf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
@@ -557,59 +385,26 @@ def test_classifier_rbf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rbf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rbf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rbf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -624,10 +419,13 @@ def test_classifier_skewed():
         X_test,
         np.sign(y_test),
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -642,50 +440,13 @@ def test_regressor_skewed():
         X_test,
         y_test,
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_classifier_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_regressor_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_classifier_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -699,10 +460,13 @@ def test_classifier_additive():
         np.sign(y_train),
         np.abs(X_test),
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -716,42 +480,6 @@ def test_regressor_additive():
         y_train,
         np.abs(X_test),
         y_test,
-        X_trans)
-
-
-def test_classifier_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        np.abs(X_train),
-        np.sign(y_train),
-        np.abs(X_test),
-        np.sign(y_test),
         X_trans,
-        True)
-
-
-def test_regressor_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        np.abs(X_train),
-        y_train,
-        np.abs(X_test),
-        y_test,
-        X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)

--- a/pyrfm/linear_model/tests/test_sgd.py
+++ b/pyrfm/linear_model/tests/test_sgd.py
@@ -8,6 +8,12 @@ from sklearn.kernel_approximation import (RBFSampler, SkewedChi2Sampler)
 from sklearn.preprocessing import StandardScaler
 from .utils_linear_model import generate_target, generate_samples
 from scipy.sparse import csr_matrix
+import pytest
+from itertools import product
+
+
+loss_reg = ['squared']
+loss_clf = ['squared_hinge', 'log', 'hinge']
 
 # generate data
 n_samples = 500
@@ -18,168 +24,165 @@ X_train = X[:n_train]
 X_test = X[n_train:]
 
 
-def test_regressor_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        for loss in ['squared']:
-            # overfitting
-            clf = SGDRegressor(transformer, max_iter=300, warm_start=True,
-                               verbose=False, fit_intercept=True, loss=loss,
-                               alpha=0.00001, intercept_decay=1e-10,
-                               random_state=0, tol=0, normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
-            assert_less_equal(l2, 0.01)
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    # overfitting
+    clf = SGDRegressor(transformer, max_iter=300, warm_start=True,
+                       verbose=False, fit_intercept=True, loss=loss,
+                       alpha=0.00001, intercept_decay=1e-10,
+                       random_state=0, tol=0, normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    l2 = np.mean((y_train[:100] - clf.predict(X_train[:100]))**2)
+    assert_less_equal(l2, 0.01)
 
-            # underfitting
-            clf_under = SGDRegressor(transformer, max_iter=100, warm_start=True,
-                                     verbose=False, fit_intercept=True, loss=loss,
-                                     alpha=100000, random_state=0,
-                                     normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    # underfitting
+    clf_under = SGDRegressor(transformer, max_iter=100, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             alpha=100000, random_state=0,
+                             normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = SGDRegressor(transformer, max_iter=100, warm_start=True,
-                                  verbose=False, fit_intercept=True,
-                                  loss=loss, alpha=1000, l1_ratio=0.9,
-                                  random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = SGDRegressor(transformer, max_iter=100, warm_start=True,
+                          verbose=False, fit_intercept=True,
+                          loss=loss, alpha=1000, l1_ratio=0.9,
+                          random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
 
-def test_classifier_regularization():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_regularization(normalize, loss):
     rng = np.random.RandomState(0)
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     transformer.fit(X)
-    for normalize in [True, False]:
-        X_trans = transformer.transform(X)
-        if normalize:
-            X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        y_train = np.sign(y_train)
-        y_test = np.sign(y_test)
-        for loss in ['squared_hinge', 'log', 'hinge']:
-            # overfitting
-            clf = SGDClassifier(transformer, max_iter=500, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.00001, intercept_decay=1e-10,
-                                random_state=0, tol=0,
-                                normalize=normalize)
-            clf.fit(X_train[:100], y_train[:100])
-            train_acc = clf.score(X_train[:100], y_train[:100])
-            assert_greater_equal(train_acc, 0.95)
+    X_trans = transformer.transform(X)
+    if normalize:
+        X_trans = StandardScaler().fit_transform(X_trans)
+    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
+    y_train = y[:n_train]
+    y_test = y[n_train:]
+    y_train = np.sign(y_train)
+    y_test = np.sign(y_test)
+    # overfitting
+    clf = SGDClassifier(transformer, max_iter=500, warm_start=True,
+                        verbose=False, fit_intercept=True, loss=loss,
+                        alpha=0.00001, intercept_decay=1e-10,
+                        random_state=0, tol=0,
+                        normalize=normalize)
+    clf.fit(X_train[:100], y_train[:100])
+    train_acc = clf.score(X_train[:100], y_train[:100])
+    assert_greater_equal(train_acc, 0.95)
 
-            # underfitting
-            clf_under = SGDClassifier(transformer, max_iter=100, warm_start=True,
-                                      verbose=False, fit_intercept=True,
-                                      loss=loss, alpha=10000,
-                                      random_state=0, normalize=normalize)
-            clf_under.fit(X_train, y_train)
-            assert_greater_equal(np.sum(clf.coef_ ** 2),
-                                 np.sum(clf_under.coef_ ** 2))
+    # underfitting
+    clf_under = SGDClassifier(transformer, max_iter=100, warm_start=True,
+                              verbose=False, fit_intercept=True,
+                              loss=loss, alpha=10000,
+                              random_state=0, normalize=normalize)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-            # l1 regularization
-            clf_l1 = SGDClassifier(transformer, max_iter=100, warm_start=True,
-                                   verbose=False, fit_intercept=True, loss=loss,
-                                   alpha=1000, l1_ratio=0.9,
-                                   random_state=0, normalize=normalize)
-            clf_l1.fit(X_train, y_train)
-            assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
+    # l1 regularization
+    clf_l1 = SGDClassifier(transformer, max_iter=100, warm_start=True,
+                           verbose=False, fit_intercept=True, loss=loss,
+                           alpha=1000, l1_ratio=0.9,
+                           random_state=0, normalize=normalize)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_)), 0)
 
 
 def _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
-                    normalize=False, sparse=True):
-    for loss in ['squared']:
-        # fast solver and slow solver
-        clf_slow = SGDRegressor(transformer, max_iter=10, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.0001, random_state=0,
-                                normalize=normalize, fast_solver=False)
-        clf_slow.fit(X_train, y_train)
+                    normalize=False, sparse=True, loss='squared'):
+    # fast solver and slow solver
+    clf_slow = SGDRegressor(transformer, max_iter=10, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=0.0001, random_state=0,
+                            normalize=normalize, fast_solver=False)
+    clf_slow.fit(X_train, y_train)
 
-        clf_fast = SGDRegressor(transformer, max_iter=10, warm_start=True,
-                                verbose=False, fit_intercept=True, loss=loss,
-                                alpha=0.0001, random_state=0,
-                                normalize=normalize, fast_solver=True)
-        clf_fast.fit(X_train, y_train)
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = SGDRegressor(transformer, loss=loss, max_iter=10,
-                                     random_state=0)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = SGDRegressor(transformer, loss=loss, max_iter=10,
-                                      random_state=0)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = SGDRegressor(transformer, max_iter=10, warm_start=True,
+                            verbose=False, fit_intercept=True, loss=loss,
+                            alpha=0.0001, random_state=0,
+                            normalize=normalize, fast_solver=True)
+    clf_fast.fit(X_train, y_train)
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = SGDRegressor(transformer, loss=loss, max_iter=10,
+                                 random_state=0)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = SGDRegressor(transformer, loss=loss, max_iter=10,
+                                  random_state=0)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = SGDRegressor(transformer, max_iter=10, shuffle=False,
-                           random_state=0, tol=0, loss=loss,
-                           warm_start=False)
-        clf.fit(X_train, y_train)
-        clf_warm = SGDRegressor(transformer, max_iter=5, shuffle=False,
-                                random_state=0, tol=0, loss=loss,
-                                warm_start=True)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = SGDRegressor(transformer, max_iter=10, shuffle=False,
+                       random_state=0, tol=0, loss=loss,
+                       warm_start=False)
+    clf.fit(X_train, y_train)
+    clf_warm = SGDRegressor(transformer, max_iter=5, shuffle=False,
+                            random_state=0, tol=0, loss=loss,
+                            warm_start=True)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
 def _test_classifier(transformer, X_train, y_train, X_test, y_test, X_trans,
-                     normalize=False, sparse=True):
-    for loss in ['squared_hinge', 'log', 'hinge']:
-        # fast solver and slow solver
-        clf_slow = SGDClassifier(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 random_state=0, normalize=normalize,
-                                 fast_solver=False)
-        clf_slow.fit(X_train[:20], y_train[:20])
+                     normalize=False, sparse=True, loss='squared_hinge'):
+    # fast solver and slow solver
+    clf_slow = SGDClassifier(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             random_state=0, normalize=normalize,
+                             fast_solver=False)
+    clf_slow.fit(X_train[:20], y_train[:20])
 
-        clf_fast = SGDClassifier(transformer, max_iter=10, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 random_state=0, normalize=normalize,
-                                 fast_solver=True)
-        clf_fast.fit(X_train[:20], y_train[:20])
-        assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
-        if sparse:
-            # dense / sparse
-            clf_dense = SGDClassifier(transformer, loss=loss, max_iter=10,
-                                      random_state=0)
-            clf_dense.fit(X_train, y_train)
-            clf_sparse = SGDClassifier(transformer, loss=loss, max_iter=10,
-                                       random_state=0)
-            clf_sparse.fit(csr_matrix(X_train), y_train)
-            assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    clf_fast = SGDClassifier(transformer, max_iter=10, warm_start=True,
+                             verbose=False, fit_intercept=True, loss=loss,
+                             random_state=0, normalize=normalize,
+                             fast_solver=True)
+    clf_fast.fit(X_train[:20], y_train[:20])
+    assert_almost_equal(clf_fast.coef_, clf_slow.coef_, decimal=6)
+    if sparse:
+        # dense / sparse
+        clf_dense = SGDClassifier(transformer, loss=loss, max_iter=10,
+                                  random_state=0)
+        clf_dense.fit(X_train, y_train)
+        clf_sparse = SGDClassifier(transformer, loss=loss, max_iter=10,
+                                   random_state=0)
+        clf_sparse.fit(csr_matrix(X_train), y_train)
+        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = SGDClassifier(transformer, max_iter=10, shuffle=False,
-                            random_state=0, tol=0, loss=loss,
-                            warm_start=False)
-        clf.fit(X_train, y_train)
-        clf_warm = SGDClassifier(transformer, max_iter=5, shuffle=False,
-                                 random_state=0, tol=0, loss=loss,
-                                 warm_start=True)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = SGDClassifier(transformer, max_iter=10, shuffle=False,
+                        random_state=0, tol=0, loss=loss,
+                        warm_start=False)
+    clf.fit(X_train, y_train)
+    clf_warm = SGDClassifier(transformer, max_iter=5, shuffle=False,
+                             random_state=0, tol=0, loss=loss,
+                             warm_start=True)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
 
-def test_classifier_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -188,10 +191,12 @@ def test_classifier_ts():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                     np.sign(y_test), X_trans)
+                     np.sign(y_test), X_trans, normalize=normalize, 
+                     loss=loss)
 
 
-def test_regressor_ts():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_ts(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = TensorSketch(n_components=100, random_state=0)
@@ -199,118 +204,43 @@ def test_regressor_ts():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_clf, [2,3,4]))
+def test_classifier_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
+    _test_classifier(transformer, X_train, np.sign(y_train), X_test,
+                     np.sign(y_test), X_trans, normalize=normalize,
+                     loss=loss)
 
 
-def test_regressor_ts_normalize():
+@pytest.mark.parametrize("normalize, loss, degree", 
+                         product([True, False], loss_reg, [2, 3, 4]))
+def test_regressor_rk(normalize, loss, degree):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
-    transformer = TensorSketch(n_components=100, random_state=0)
+    transformer = RandomKernel(n_components=100, random_state=0,
+                                degree=degree)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(transformer, X_train, np.sign(y_train), X_test,
-                         np.sign(y_test), X_trans)
-
-
-def test_regressor_rk():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_classifier(
-            transformer,
-            X_train,
-            np.sign(y_train),
-            X_test,
-            np.sign(y_test),
-            X_trans,
-            True)
-
-
-def test_regressor_rk_normalize():
-    rng = np.random.RandomState(0)
-    for degree in range(2, 5):
-        # approximate kernel mapping
-        transformer = RandomKernel(n_components=100, random_state=0,
-                                   degree=degree)
-        X_trans = transformer.fit_transform(X)
-        X_trans = StandardScaler().fit_transform(X_trans)
-
-        y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-        y_train = y[:n_train]
-        y_test = y[n_train:]
-        _test_regressor(
-            transformer,
-            X_train,
-            y_train,
-            X_test,
-            y_test,
-            X_trans,
-            True)
-
-
-def test_classifier_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -325,10 +255,13 @@ def test_classifier_rk_as():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rk_as():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rk_as(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomKernel(n_components=100, random_state=0,
@@ -337,50 +270,12 @@ def test_regressor_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rk_as_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomKernel(n_components=100, random_state=0,
-                               kernel='all_subsets')
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -394,10 +289,13 @@ def test_classifier_rm():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rm():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rm(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomMaclaurin(n_components=100, random_state=0)
@@ -405,48 +303,12 @@ def test_regressor_rm():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True)
-
-
-def test_regressor_rm_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomMaclaurin(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
-
-
-def test_classifier_rf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
@@ -460,59 +322,26 @@ def test_classifier_rf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_rbf():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
@@ -526,59 +355,26 @@ def test_classifier_rbf():
         np.sign(y_train),
         X_test,
         np.sign(y_test),
-        X_trans)
-
-
-def test_regressor_rbf():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans)
-
-
-def test_classifier_rbf_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
         X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_rbf_normalize():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_rbf(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = RBFSampler(n_components=100, random_state=0, gamma=10)
     X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True)
+    _test_regressor(transformer, X_train, y_train, X_test, y_test, X_trans,
+                    normalize=normalize, loss=loss)
 
 
-def test_classifier_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -593,10 +389,13 @@ def test_classifier_skewed():
         X_test,
         np.sign(y_test),
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_skewed():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_skewed(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = SkewedChi2Sampler(n_components=100, random_state=0)
@@ -611,50 +410,13 @@ def test_regressor_skewed():
         X_test,
         y_test,
         X_trans,
-        sparse=False)
+        sparse=False,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_classifier_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        X_train,
-        np.sign(y_train),
-        X_test,
-        np.sign(y_test),
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_regressor_skewed_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = SkewedChi2Sampler(n_components=100, random_state=0)
-    X_trans = transformer.fit_transform(X)
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        X_trans,
-        True,
-        sparse=False)
-
-
-def test_classifier_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_clf))
+def test_classifier_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -668,10 +430,13 @@ def test_classifier_additive():
         np.sign(y_train),
         np.abs(X_test),
         np.sign(y_test),
-        X_trans)
+        X_trans,
+        normalize=normalize,
+        loss=loss)
 
 
-def test_regressor_additive():
+@pytest.mark.parametrize("normalize, loss", product([True, False], loss_reg))
+def test_regressor_additive(normalize, loss):
     rng = np.random.RandomState(0)
     # approximate kernel mapping
     transformer = AdditiveChi2Sampler()
@@ -685,42 +450,6 @@ def test_regressor_additive():
         y_train,
         np.abs(X_test),
         y_test,
-        X_trans)
-
-
-def test_classifier_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_classifier(
-        transformer,
-        np.abs(X_train),
-        np.sign(y_train),
-        np.abs(X_test),
-        np.sign(y_test),
         X_trans,
-        True)
-
-
-def test_regressor_additive_normalize():
-    rng = np.random.RandomState(0)
-    # approximate kernel mapping
-    transformer = AdditiveChi2Sampler()
-    X_trans = transformer.fit_transform(np.abs(X))
-    X_trans = StandardScaler().fit_transform(X_trans)
-    y, coef = generate_target(X_trans, rng, -0.1, 0.1)
-    y_train = y[:n_train]
-    y_test = y[n_train:]
-    _test_regressor(
-        transformer,
-        np.abs(X_train),
-        y_train,
-        np.abs(X_test),
-        y_test,
-        X_trans,
-        True)
+        normalize=normalize,
+        loss=loss)

--- a/pyrfm/linear_model/tests/test_sgd_doubly.py
+++ b/pyrfm/linear_model/tests/test_sgd_doubly.py
@@ -6,9 +6,13 @@ from pyrfm import (TensorSketch, RandomKernel, RandomMaclaurin, RandomFourier,
                    DoublySGDClassifier, DoublySGDRegressor)
 from sklearn.kernel_approximation import RBFSampler, SkewedChi2Sampler
 from scipy.sparse import csr_matrix
-
 from sklearn.preprocessing import StandardScaler
 from .utils_linear_model import generate_target, generate_samples
+import pytest
+from itertools import product
+
+loss_reg = ['squared']
+loss_clf = ['squared_hinge', 'hinge', 'log']
 
 # generate data
 n_samples = 150
@@ -18,133 +22,131 @@ X = generate_samples(n_samples, n_features, 0)
 X_train = X[:n_train]
 X_test = X[n_train:]
 
-import pstats, cProfile
 
-def _test_regressor(transform, y_train, y_test,
-                    X_trans, max_iter=100, eta0=0.01):
-    for loss in ['squared']:
-        
-        # learn?
-        clf = DoublySGDRegressor(transform, max_iter=max_iter, warm_start=True,
-                                 verbose=False, fit_intercept=True, loss=loss,
-                                 alpha=1e-7, intercept_decay=1e-7,
-                                 random_state=0, tol=0, power_t=1, eta0=eta0)
-        clf.fit(X_train, y_train)
-        l2 = np.mean((y_train - clf.predict(X_train))**2)
-        assert_less_equal(l2, 0.01)
-        
-        # compare the norms of coefs: overfitting vs underfitting
-        clf_over = DoublySGDRegressor(transform, warm_start=True,
-                                      verbose=False, fit_intercept=True, loss=loss,
-                                      alpha=1e-7, intercept_decay=1e-7,
-                                      random_state=0, tol=0, power_t=1, eta0=eta0)
-        clf_over.fit(X_train, y_train)
-        # underfitting
-        clf_under = DoublySGDRegressor(transform, warm_start=True,
-                                       verbose=False, fit_intercept=True, loss=loss,
-                                       alpha=10000, random_state=0, power_t=1,
-                                       eta0=eta0)
-        clf_under.fit(X_train, y_train)
-        assert_greater_equal(np.sum(clf_over.coef_ ** 2),
-                             np.sum(clf_under.coef_ ** 2))
+def _test_regressor(transform, y_train, y_test, X_trans, max_iter=100, 
+                    eta0=0.01, loss='squared'):
+    # learn?
+    clf = DoublySGDRegressor(transform, max_iter=max_iter, warm_start=True,
+                                verbose=False, fit_intercept=True, loss=loss,
+                                alpha=1e-7, intercept_decay=1e-7,
+                                random_state=0, tol=0, power_t=1, eta0=eta0)
+    clf.fit(X_train, y_train)
+    l2 = np.mean((y_train - clf.predict(X_train))**2)
+    assert_less_equal(l2, 0.01)
+    
+    # compare the norms of coefs: overfitting vs underfitting
+    clf_over = DoublySGDRegressor(transform, warm_start=True,
+                                    verbose=False, fit_intercept=True, loss=loss,
+                                    alpha=1e-7, intercept_decay=1e-7,
+                                    random_state=0, tol=0, power_t=1, eta0=eta0)
+    clf_over.fit(X_train, y_train)
+    # underfitting
+    clf_under = DoublySGDRegressor(transform, warm_start=True,
+                                    verbose=False, fit_intercept=True, loss=loss,
+                                    alpha=10000, random_state=0, power_t=1,
+                                    eta0=eta0)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf_over.coef_ ** 2),
+                            np.sum(clf_under.coef_ ** 2))
 
-        # use same seed?
-        assert_almost_equal(clf_over.predict(X_train),
-                            clf_over.predict(X_train))
-        
-        # l1 regularization
-        clf_l1 = DoublySGDRegressor(transform,
-                                    warm_start=True, verbose=False,
-                                    fit_intercept=True, loss=loss,
-                                    alpha=1000, l1_ratio=0.9, random_state=0,
-                                    power_t=1, eta0=eta0)
-        clf_l1.fit(X_train, y_train)
-        assert_almost_equal(np.sum(np.abs(clf_l1.coef_[:-2])), 0)
+    # use same seed?
+    assert_almost_equal(clf_over.predict(X_train),
+                        clf_over.predict(X_train))
+    
+    # l1 regularization
+    clf_l1 = DoublySGDRegressor(transform,
+                                warm_start=True, verbose=False,
+                                fit_intercept=True, loss=loss,
+                                alpha=1000, l1_ratio=0.9, random_state=0,
+                                power_t=1, eta0=eta0)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_[:-2])), 0)
 
-        # dense / sparse
-        clf_dense = DoublySGDRegressor(transform, loss=loss, max_iter=10,
-                                       random_state=0, eta0=eta0, verbose=False)
-        clf_dense.fit(X_train, y_train)
-        clf_sparse = DoublySGDRegressor(transform, loss=loss, max_iter=10,
-                                        random_state=0, eta0=eta0, verbose=False)
-        clf_sparse.fit(csr_matrix(X_train), y_train)
-        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    # dense / sparse
+    clf_dense = DoublySGDRegressor(transform, loss=loss, max_iter=10,
+                                    random_state=0, eta0=eta0, verbose=False)
+    clf_dense.fit(X_train, y_train)
+    clf_sparse = DoublySGDRegressor(transform, loss=loss, max_iter=10,
+                                    random_state=0, eta0=eta0, verbose=False)
+    clf_sparse.fit(csr_matrix(X_train), y_train)
+    assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = DoublySGDRegressor(transform, max_iter=10, shuffle=False,
-                                 random_state=0, tol=0, loss=loss,
-                                 warm_start=False, verbose=False, eta0=eta0)
-        clf.fit(X_train, y_train)
-        clf_warm = DoublySGDRegressor(transform, max_iter=5, shuffle=False,
-                                      random_state=0, tol=0, loss=loss,
-                                      warm_start=True, verbose=False, eta0=eta0)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_[-1], clf_warm.coef_[-1])
+    # warm_start
+    clf = DoublySGDRegressor(transform, max_iter=10, shuffle=False,
+                                random_state=0, tol=0, loss=loss,
+                                warm_start=False, verbose=False, eta0=eta0)
+    clf.fit(X_train, y_train)
+    clf_warm = DoublySGDRegressor(transform, max_iter=5, shuffle=False,
+                                    random_state=0, tol=0, loss=loss,
+                                    warm_start=True, verbose=False, eta0=eta0)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_[-1], clf_warm.coef_[-1])
 
 
 def _test_classifier(transform, y_train, y_test, X_trans, max_iter=100,
-                     eta0=0.01):
-    for loss in ['squared_hinge', 'hinge', 'logistic']:
-        # learn?
-        clf = DoublySGDClassifier(transform, max_iter=max_iter,
-                                  verbose=True, fit_intercept=True, loss=loss,
-                                  alpha=1e-7, intercept_decay=1e-7, eta0=eta0,
-                                  random_state=0, tol=0, power_t=1)
-        clf.fit(X_train, y_train)
-        train_acc = clf.score(X_train, y_train)
-        assert_greater_equal(train_acc, .80)
+                     eta0=0.01, loss='squared_hinge'):
+    #  learn?
+    clf = DoublySGDClassifier(transform, max_iter=max_iter,
+                              verbose=True, fit_intercept=True, loss=loss,
+                              alpha=1e-7, intercept_decay=1e-7, eta0=eta0,
+                              random_state=0, tol=0, power_t=1)
+    clf.fit(X_train, y_train)
+    train_acc = clf.score(X_train, y_train)
+    assert_greater_equal(train_acc, .80)
         
-        # compare the norms of coefs: overfitting vs underfitting
-        clf_over = DoublySGDClassifier(transform, warm_start=True,
-                                       verbose=False, fit_intercept=True,
-                                       loss=loss, alpha=1e-7,
-                                       intercept_decay=1e-7, eta0=eta0,
-                                       random_state=0, tol=0, power_t=1)
-        clf_over.fit(X_train, y_train)
-        clf_under = DoublySGDClassifier(transform, warm_start=True,
-                                        verbose=False, fit_intercept=True,
-                                        loss=loss, alpha=1000, random_state=0,
-                                        power_t=1, eta0=eta0)
-        clf_under.fit(X_train, y_train)
-        assert_greater_equal(np.sum(clf_over.coef_ ** 2),
-                             np.sum(clf_under.coef_ ** 2))
+    # compare the norms of coefs: overfitting vs underfitting
+    clf_over = DoublySGDClassifier(transform, warm_start=True,
+                                   verbose=False, fit_intercept=True,
+                                   loss=loss, alpha=1e-7,
+                                   intercept_decay=1e-7, eta0=eta0,
+                                   random_state=0, tol=0, power_t=1)
+    clf_over.fit(X_train, y_train)
+    clf_under = DoublySGDClassifier(transform, warm_start=True,
+                                    verbose=False, fit_intercept=True,
+                                    loss=loss, alpha=1000, random_state=0,
+                                    power_t=1, eta0=eta0)
+    clf_under.fit(X_train, y_train)
+    assert_greater_equal(np.sum(clf_over.coef_ ** 2),
+                         np.sum(clf_under.coef_ ** 2))
 
-        # use same seed?
-        assert_almost_equal(clf_over.decision_function(X_train),
-                            clf_over.decision_function(X_train))
+    # use same seed?
+    assert_almost_equal(clf_over.decision_function(X_train),
+                        clf_over.decision_function(X_train))
         
-        # l1 regularization
-        clf_l1 = DoublySGDClassifier(transform, verbose=False,
-                                     fit_intercept=True,
-                                     loss=loss, alpha=1000, l1_ratio=0.9,
-                                     random_state=0, power_t=1, eta0=eta0)
-        clf_l1.fit(X_train, y_train)
-        assert_almost_equal(np.sum(np.abs(clf_l1.coef_[:-2])), 0)
+    # l1 regularization
+    clf_l1 = DoublySGDClassifier(transform, verbose=False,
+                                 fit_intercept=True,
+                                 loss=loss, alpha=1000, l1_ratio=0.9,
+                                 random_state=0, power_t=1, eta0=eta0)
+    clf_l1.fit(X_train, y_train)
+    assert_almost_equal(np.sum(np.abs(clf_l1.coef_[:-2])), 0)
 
-        # dense / sparse
-        clf_dense = DoublySGDClassifier(transform, loss=loss, max_iter=10,
-                                        random_state=0, eta0=eta0)
-        clf_dense.fit(X_train, y_train)
-        clf_sparse = DoublySGDClassifier(transform, loss=loss, max_iter=10,
-                                         random_state=0, eta0=eta0)
-        clf_sparse.fit(csr_matrix(X_train), y_train)
-        assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
+    # dense / sparse
+    clf_dense = DoublySGDClassifier(transform, loss=loss, max_iter=10,
+                                    random_state=0, eta0=eta0)
+    clf_dense.fit(X_train, y_train)
+    clf_sparse = DoublySGDClassifier(transform, loss=loss, max_iter=10,
+                                     random_state=0, eta0=eta0)
+    clf_sparse.fit(csr_matrix(X_train), y_train)
+    assert_almost_equal(clf_dense.coef_, clf_sparse.coef_)
 
-        # warm_start
-        clf = DoublySGDClassifier(transform, max_iter=10, shuffle=False,
-                                  random_state=0, tol=0, loss=loss, eta0=eta0)
-        clf.fit(X_train, y_train)
-        clf_warm = DoublySGDClassifier(transform, max_iter=5, shuffle=False,
-                                       random_state=0, tol=0, loss=loss,
-                                       warm_start=True, eta0=eta0)
-        clf_warm.fit(X_train, y_train)
-        clf_warm.fit(X_train, y_train)
-        assert_almost_equal(clf.t_, clf_warm.t_)
-        assert_almost_equal(clf.coef_, clf_warm.coef_)
+    # warm_start
+    clf = DoublySGDClassifier(transform, max_iter=10, shuffle=False,
+                              random_state=0, tol=0, loss=loss, eta0=eta0)
+    clf.fit(X_train, y_train)
+    clf_warm = DoublySGDClassifier(transform, max_iter=5, shuffle=False,
+                                   random_state=0, tol=0, loss=loss,
+                                   warm_start=True, eta0=eta0)
+    clf_warm.fit(X_train, y_train)
+    clf_warm.fit(X_train, y_train)
+    assert_almost_equal(clf.t_, clf_warm.t_)
+    assert_almost_equal(clf.coef_, clf_warm.coef_)
 
-def test_sgd_classifier_rf():
+
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_rf(loss):
     rng = np.random.RandomState(0)
     transform = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transform.fit_transform(X)
@@ -152,20 +154,23 @@ def test_sgd_classifier_rf():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
-                     max_iter=500)
+                     max_iter=500, loss=loss)
 
 
-def test_sgd_regressor_rf():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_rf(loss):
     rng = np.random.RandomState(0)
     transform = RandomFourier(n_components=100, random_state=0, gamma=10)
     X_trans = transform.fit_transform(X)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transform, y_train, y_test, X_trans, max_iter=100)
+    _test_regressor(transform, y_train, y_test, X_trans, max_iter=100,
+                    loss=loss)
 
 
-def test_sgd_classifier_rf_use_offset():
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_rf_use_offset(loss):
     rng = np.random.RandomState(0)
     transform = RandomFourier(n_components=100, random_state=0, gamma=10,
                               use_offset=True)
@@ -174,10 +179,11 @@ def test_sgd_classifier_rf_use_offset():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
-                     max_iter=500)
+                     max_iter=500, loss=loss)
 
 
-def test_sgd_regressor_rf_use_offset():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_rf_use_offset(loss):
     rng = np.random.RandomState(0)
     transform = RandomFourier(n_components=100, random_state=0, gamma=10,
                               use_offset=True)
@@ -185,10 +191,11 @@ def test_sgd_regressor_rf_use_offset():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transform, y_train, y_test, X_trans)
+    _test_regressor(transform, y_train, y_test, X_trans, loss=loss)
 
 
-def test_sgd_classifier_rk():
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_rk(loss):
     rng = np.random.RandomState(0)
     for degree in range(2, 5):
         transform = RandomKernel(n_components=100, random_state=0,
@@ -198,10 +205,11 @@ def test_sgd_classifier_rk():
         y_train = y[:n_train]
         y_test = y[n_train:]
         _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
-                         max_iter=100, eta0=.1)
+                         max_iter=100, eta0=.1, loss=loss)
 
 
-def test_sgd_regressor_rk():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_rk(loss):
     rng = np.random.RandomState(0)
     for degree in range(2, 5):
         transform = RandomKernel(n_components=100, random_state=0,
@@ -210,10 +218,11 @@ def test_sgd_regressor_rk():
         y, coef = generate_target(X_trans, rng, -0.1, 0.1)
         y_train = y[:n_train]
         y_test = y[n_train:]
-        _test_regressor(transform, y_train, y_test, X_trans)
+        _test_regressor(transform, y_train, y_test, X_trans, loss=loss)
 
 
-def test_sgd_classifier_rk_as():
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_rk_as(loss):
     rng = np.random.RandomState(0)
     transform = RandomKernel(n_components=100, random_state=0,
                              kernel='all_subsets')
@@ -221,10 +230,12 @@ def test_sgd_classifier_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans)
+    _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
+                     loss=loss)
 
 
-def test_sgd_regressor_rk_as():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_rk_as(loss):
     rng = np.random.RandomState(0)
     transform = RandomKernel(n_components=100, random_state=0,
                              kernel='all_subsets')
@@ -232,40 +243,45 @@ def test_sgd_regressor_rk_as():
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transform, y_train, y_test, X_trans)
+    _test_regressor(transform, y_train, y_test, X_trans, loss=loss)
 
 
-def test_sgd_classifier_rm():
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_rm(loss):
     rng = np.random.RandomState(0)
     transform = RandomMaclaurin(n_components=100, random_state=0)
     X_trans = transform.fit_transform(X)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans)
+    _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
+                     loss=loss)
 
 
-def test_sgd_regressor_rm():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_rm(loss):
     rng = np.random.RandomState(0)
     transform = RandomMaclaurin(n_components=100, random_state=0)
     X_trans = transform.fit_transform(X)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transform, y_train, y_test, X_trans)
+    _test_regressor(transform, y_train, y_test, X_trans, loss=loss)
 
 
-def test_sgd_regressor_rbf():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_rbf(loss):
     rng = np.random.RandomState(0)
     transform = RBFSampler(n_components=100, gamma=10, random_state=0)
     X_trans = transform.fit_transform(X)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transform, y_train, y_test, X_trans)
+    _test_regressor(transform, y_train, y_test, X_trans, loss=loss)
 
 
-def test_sgd_classifier_rbf():
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_rbf(loss):
     rng = np.random.RandomState(0)
     transform = RBFSampler(n_components=100, gamma=10, random_state=0)
     X_trans = transform.fit_transform(X)
@@ -273,20 +289,22 @@ def test_sgd_classifier_rbf():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
-                     max_iter=500, eta0=.01)
+                     max_iter=500, eta0=.01, loss=loss)
 
 
-def test_sgd_regressor_skewed():
+@pytest.mark.parametrize("loss", loss_reg)
+def test_sgd_regressor_skewed(loss):
     rng = np.random.RandomState(0)
     transform = SkewedChi2Sampler(random_state=0)
     X_trans = transform.fit_transform(X)
     y, coef = generate_target(X_trans, rng, -0.1, 0.1)
     y_train = y[:n_train]
     y_test = y[n_train:]
-    _test_regressor(transform, y_train, y_test, X_trans)
+    _test_regressor(transform, y_train, y_test, X_trans, loss=loss)
 
 
-def test_sgd_classifier_skewed():
+@pytest.mark.parametrize("loss", loss_clf)
+def test_sgd_classifier_skewed(loss):
     rng = np.random.RandomState(0)
     transform = SkewedChi2Sampler(random_state=0)
     X_trans = transform.fit_transform(X)
@@ -294,4 +312,4 @@ def test_sgd_classifier_skewed():
     y_train = y[:n_train]
     y_test = y[n_train:]
     _test_classifier(transform, np.sign(y_train), np.sign(y_test), X_trans,
-                     max_iter=300)
+                     max_iter=300, loss=loss)

--- a/pyrfm/random_feature/orthogonal_random_feature.py
+++ b/pyrfm/random_feature/orthogonal_random_feature.py
@@ -140,12 +140,12 @@ class OrthogonalRandomFeature(BaseEstimator, TransformerMixin):
         random_weights_ = []
         for _ in range(n_stacks):
             W = self.distribution(random_state, size)
-            S = np.diag(chi.rvs(df=n_features, size=n_features))
+            S = np.diag(chi.rvs(df=n_features, size=n_features,
+                                random_state=random_state))
             SQ, _ = qr_multiply(W, S)
             random_weights_ += [SQ]
 
         self.random_weights_ = np.vstack(random_weights_).T
-
         self.random_offset_ = None
         if self.random_fourier:
             self.random_weights_ *= sqrt(2*gamma)

--- a/pyrfm/random_feature/tests/test_compact_random_features.py
+++ b/pyrfm/random_feature/tests/test_compact_random_features.py
@@ -7,6 +7,7 @@ from pyrfm import (CompactRandomFeature, RandomProjection,
                    SubsampledRandomHadamard,
                    RandomMaclaurin, RandomFourier, RandomKernel, TensorSketch)
 from sklearn.kernel_approximation import RBFSampler
+import pytest
 
 
 def polynomial(X, Y, degree, bias=0):
@@ -26,123 +27,123 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_compact_random_feature_random_maclaurin():
+@pytest.mark.parametrize("down", [RandomProjection, SubsampledRandomHadamard])
+def test_compact_random_feature_random_maclaurin(down):
     # compute exact kernel
-    for down in [RandomProjection, SubsampledRandomHadamard]:
-        for degree in range(2, 5):
-            # approximate kernel mapping
-            transform_up = RandomMaclaurin(n_components=100, degree=degree,
-                                           random_state=0, kernel='poly')
-            transform_down = down(n_components=50, random_state=0)
-            X_trans_naive = transform_down.fit_transform(
-                transform_up.fit_transform(X)
-            )
-
-            transform_up = RandomMaclaurin(n_components=100, degree=degree,
-                                           random_state=0, kernel='poly')
-            transform_down = down(n_components=50, random_state=0)
-            transformer = CompactRandomFeature(transformer_up=transform_up,
-                                               degree=degree,
-                                               transformer_down=transform_down)
-            X_trans = transformer.fit_transform(X)
-            assert_allclose(X_trans_naive, X_trans)
-
-
-def test_compact_random_feature_random_fourier():
-    for down in [RandomProjection, SubsampledRandomHadamard]:
-        for gamma in [0.1, 1, 10]:
-            # approximate kernel mapping
-            transform_up = RandomFourier(n_components=100, gamma=gamma,
-                                         random_state=0)
-            transform_down = down(n_components=50, random_state=0)
-            X_trans_naive = transform_down.fit_transform(
-                transform_up.fit_transform(X)
-            )
-
-            transform_up = RandomFourier(n_components=100, gamma=gamma,
-                                         random_state=0)
-            transform_down = down(n_components=50, random_state=0)
-            transformer = CompactRandomFeature(transformer_up=transform_up,
-                                               transformer_down=transform_down)
-            X_trans = transformer.fit_transform(X)
-            assert_allclose(X_trans_naive, X_trans)
-
-
-def test_compact_random_feature_tensor_sketch():
-    for down in [RandomProjection, SubsampledRandomHadamard]:
-        for degree in range(2, 5):
-            # approximate kernel mapping
-            transform_up = TensorSketch(degree=degree, random_state=0,
-                                        n_components=100)
-            transform_down = down(n_components=50, random_state=0)
-            X_trans_naive = transform_down.fit_transform(
-                transform_up.fit_transform(X)
-            )
-
-            transform_up = TensorSketch(degree=degree, random_state=0,
-                                        n_components=100)
-            transform_down = down(n_components=50, random_state=0)
-            transformer = CompactRandomFeature(transformer_up=transform_up,
-                                               transformer_down=transform_down)
-            X_trans = transformer.fit_transform(X)
-            print(X_trans)
-            print(X_trans_naive)
-            assert_allclose(X_trans_naive, X_trans)
-
-
-def test_compact_random_feature_random_kernel():
-    for down in [RandomProjection, SubsampledRandomHadamard]:
-        for degree in range(2, 5):
-            # approximate kernel mapping
-            transform_up = RandomKernel(degree=degree, random_state=0,
-                                        n_components=100)
-            transform_down = down(n_components=50, random_state=0)
-            X_trans_naive = transform_down.fit_transform(
-                transform_up.fit_transform(X)
-            )
-
-            transform_up = RandomKernel(degree=degree, random_state=0,
-                                        n_components=100)
-            transform_down = down(n_components=50, random_state=0)
-            transformer = CompactRandomFeature(transformer_up=transform_up,
-                                               transformer_down=transform_down)
-            X_trans = transformer.fit_transform(X)
-            assert_allclose(X_trans_naive, X_trans)
-
-
-def test_compact_random_feature_random_kernel_all_subsets():
-    for down in [RandomProjection, SubsampledRandomHadamard]:
+    for degree in range(2, 5):
         # approximate kernel mapping
-        transform_up = RandomKernel(kernel='all_subsets', random_state=0,
+        transform_up = RandomMaclaurin(n_components=100, degree=degree,
+                                        random_state=0, kernel='poly')
+        transform_down = down(n_components=50, random_state=0)
+        X_trans_naive = transform_down.fit_transform(
+            transform_up.fit_transform(X)
+        )
+
+        transform_up = RandomMaclaurin(n_components=100, degree=degree,
+                                        random_state=0, kernel='poly')
+        transform_down = down(n_components=50, random_state=0)
+        transformer = CompactRandomFeature(transformer_up=transform_up,
+                                            degree=degree,
+                                            transformer_down=transform_down)
+        X_trans = transformer.fit_transform(X)
+        assert_allclose(X_trans_naive, X_trans)
+
+
+@pytest.mark.parametrize("down", [RandomProjection, SubsampledRandomHadamard])
+def test_compact_random_feature_random_fourier(down):
+    for gamma in [0.1, 1, 10]:
+        # approximate kernel mapping
+        transform_up = RandomFourier(n_components=100, gamma=gamma,
+                                        random_state=0)
+        transform_down = down(n_components=50, random_state=0)
+        X_trans_naive = transform_down.fit_transform(
+            transform_up.fit_transform(X)
+        )
+
+        transform_up = RandomFourier(n_components=100, gamma=gamma,
+                                        random_state=0)
+        transform_down = down(n_components=50, random_state=0)
+        transformer = CompactRandomFeature(transformer_up=transform_up,
+                                            transformer_down=transform_down)
+        X_trans = transformer.fit_transform(X)
+        assert_allclose(X_trans_naive, X_trans)
+
+
+@pytest.mark.parametrize("down", [RandomProjection, SubsampledRandomHadamard])
+def test_compact_random_feature_tensor_sketch(down):
+    for degree in range(2, 5):
+    # approximate kernel mapping
+        transform_up = TensorSketch(degree=degree, random_state=0,
                                     n_components=100)
         transform_down = down(n_components=50, random_state=0)
         X_trans_naive = transform_down.fit_transform(
             transform_up.fit_transform(X)
         )
 
-        transform_up = RandomKernel(kernel='all_subsets', random_state=0,
+        transform_up = TensorSketch(degree=degree, random_state=0,
                                     n_components=100)
         transform_down = down(n_components=50, random_state=0)
         transformer = CompactRandomFeature(transformer_up=transform_up,
-                                           transformer_down=transform_down)
+                                            transformer_down=transform_down)
+        X_trans = transformer.fit_transform(X)
+        print(X_trans)
+        print(X_trans_naive)
+        assert_allclose(X_trans_naive, X_trans)
+
+
+@pytest.mark.parametrize("down", [RandomProjection, SubsampledRandomHadamard])
+def test_compact_random_feature_random_kernel(down):
+    for degree in range(2, 5):
+        # approximate kernel mapping
+        transform_up = RandomKernel(degree=degree, random_state=0,
+                                    n_components=100)
+        transform_down = down(n_components=50, random_state=0)
+        X_trans_naive = transform_down.fit_transform(
+            transform_up.fit_transform(X)
+        )
+
+        transform_up = RandomKernel(degree=degree, random_state=0,
+                                    n_components=100)
+        transform_down = down(n_components=50, random_state=0)
+        transformer = CompactRandomFeature(transformer_up=transform_up,
+                                            transformer_down=transform_down)
         X_trans = transformer.fit_transform(X)
         assert_allclose(X_trans_naive, X_trans)
 
 
-def test_compact_random_feature_rbfsampler():
-    for down in [RandomProjection, SubsampledRandomHadamard]:
-        for gamma in [0.1, 1, 10]:
-            # approximate kernel mapping
-            transform_up = RBFSampler(gamma=gamma, random_state=0,
-                                      n_components=100)
-            transform_down = down(n_components=50, random_state=0)
-            X_trans_naive = transform_down.fit_transform(
-                transform_up.fit_transform(X)
-            )
-            transform_up = RBFSampler(gamma=gamma, random_state=0,
-                                      n_components=100)
-            transform_down = down(n_components=50, random_state=0)
-            transformer = CompactRandomFeature(transformer_up=transform_up,
-                                               transformer_down=transform_down)
-            X_trans = transformer.fit_transform(X)
-            assert_allclose(X_trans_naive, X_trans)
+@pytest.mark.parametrize("down", [RandomProjection, SubsampledRandomHadamard])
+def test_compact_random_feature_random_kernel_all_subsets(down):
+    # approximate kernel mapping
+    transform_up = RandomKernel(kernel='all_subsets', random_state=0,
+                                n_components=100)
+    transform_down = down(n_components=50, random_state=0)
+    X_trans_naive = transform_down.fit_transform(
+        transform_up.fit_transform(X)
+    )
+
+    transform_up = RandomKernel(kernel='all_subsets', random_state=0,
+                                n_components=100)
+    transform_down = down(n_components=50, random_state=0)
+    transformer = CompactRandomFeature(transformer_up=transform_up,
+                                        transformer_down=transform_down)
+    X_trans = transformer.fit_transform(X)
+    assert_allclose(X_trans_naive, X_trans)
+
+
+@pytest.mark.parametrize("down", [RandomProjection, SubsampledRandomHadamard])
+def test_compact_random_feature_rbfsampler(down):
+    for gamma in [0.1, 1, 10]:
+        # approximate kernel mapping
+        transform_up = RBFSampler(gamma=gamma, random_state=0,
+                                    n_components=100)
+        transform_down = down(n_components=50, random_state=0)
+        X_trans_naive = transform_down.fit_transform(
+            transform_up.fit_transform(X)
+        )
+        transform_up = RBFSampler(gamma=gamma, random_state=0,
+                                    n_components=100)
+        transform_down = down(n_components=50, random_state=0)
+        transformer = CompactRandomFeature(transformer_up=transform_up,
+                                            transformer_down=transform_down)
+        X_trans = transformer.fit_transform(X)
+        assert_allclose(X_trans_naive, X_trans)

--- a/pyrfm/random_feature/tests/test_kernels.py
+++ b/pyrfm/random_feature/tests/test_kernels.py
@@ -5,8 +5,8 @@ from sklearn.utils.extmath import safe_sparse_dot
 
 from itertools import product, combinations
 from functools import reduce
-
 import pyrfm
+import pytest
 
 rng = np.random.RandomState(0)
 X = rng.random_sample(size=(10, 8))
@@ -68,62 +68,62 @@ def D(X, P, degree, dense_output=True):
                            dense_output)
 
 
-def test_anova_kernel():
-    for degree in range(2, 4):
-        expected = np.zeros((X.shape[0], Y.shape[0]))
-        for i in range(X.shape[0]):
-            for j in range(Y.shape[0]):
-                expected[i, j] = dumb_anova(X[i], Y[j], degree=degree)
+@pytest.mark.parametrize("degree", [2, 3, 4, 5])
+def test_anova_kernel(degree):
+    expected = np.zeros((X.shape[0], Y.shape[0]))
+    for i in range(X.shape[0]):
+        for j in range(Y.shape[0]):
+            expected[i, j] = dumb_anova(X[i], Y[j], degree=degree)
 
-        anova = pyrfm.anova(X, Y, degree)
-        assert_array_almost_equal(expected, anova, decimal=4)
+    anova = pyrfm.anova(X, Y, degree)
+    assert_array_almost_equal(expected, anova, decimal=4)
 
-        anova = pyrfm.anova_fast(X, Y, degree)
-        assert_array_almost_equal(expected, anova, decimal=4)
-
-
-def test_anova_kernel_sparse():
-    for degree in range(2, 4):
-        expected = np.zeros((X.shape[0], Y.shape[0]))
-        for i in range(X.shape[0]):
-            for j in range(Y.shape[0]):
-                expected[i, j] = dumb_anova(X[i], Y[j], degree=degree)
-
-        anova = pyrfm.anova(csr_matrix(X), Y, degree, True)
-        assert_array_almost_equal(expected, anova, decimal=4)
-
-        anova = pyrfm.anova(csr_matrix(X), Y, degree, False)
-        assert_array_almost_equal(expected, anova, decimal=4)
-        
-        anova = pyrfm.anova(X, csr_matrix(Y), degree, True)
-        assert_array_almost_equal(expected, anova, decimal=4)
-
-        anova = pyrfm.anova(X, csr_matrix(Y), degree, False)
-        assert_array_almost_equal(expected, anova, decimal=4)
-
-        anova = pyrfm.anova(csr_matrix(X), csr_matrix(Y), degree, True)
-        assert_array_almost_equal(expected, anova, decimal=4)
-
-        anova = pyrfm.anova(csr_matrix(X), csr_matrix(Y), degree, False)
-        assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+    anova = pyrfm.anova_fast(X, Y, degree)
+    assert_array_almost_equal(expected, anova, decimal=4)
 
 
-def test_anova_kernel_fast_sparse():
-    for degree in range(2, 4):
-        expected = np.zeros((X.shape[0], Y.shape[0]))
-        for i in range(X.shape[0]):
-            for j in range(Y.shape[0]):
-                expected[i, j] = dumb_anova(X[i], Y[j], degree=degree)
+@pytest.mark.parametrize("degree", [2, 3, 4, 5])
+def test_anova_kernel_sparse(degree):
+    expected = np.zeros((X.shape[0], Y.shape[0]))
+    for i in range(X.shape[0]):
+        for j in range(Y.shape[0]):
+            expected[i, j] = dumb_anova(X[i], Y[j], degree=degree)
 
-        anova = pyrfm.anova_fast(csr_matrix(X), Y, degree, False)
-        assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+    anova = pyrfm.anova(csr_matrix(X), Y, degree, True)
+    assert_array_almost_equal(expected, anova, decimal=4)
 
-        anova = pyrfm.anova_fast(X, csr_matrix(Y), degree, False)
-        assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+    anova = pyrfm.anova(csr_matrix(X), Y, degree, False)
+    assert_array_almost_equal(expected, anova, decimal=4)
+    
+    anova = pyrfm.anova(X, csr_matrix(Y), degree, True)
+    assert_array_almost_equal(expected, anova, decimal=4)
 
-        anova = pyrfm.anova_fast(csr_matrix(X), csr_matrix(Y), degree, False)
-        assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+    anova = pyrfm.anova(X, csr_matrix(Y), degree, False)
+    assert_array_almost_equal(expected, anova, decimal=4)
 
+    anova = pyrfm.anova(csr_matrix(X), csr_matrix(Y), degree, True)
+    assert_array_almost_equal(expected, anova, decimal=4)
+
+    anova = pyrfm.anova(csr_matrix(X), csr_matrix(Y), degree, False)
+    print(type(anova))
+    assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+
+
+@pytest.mark.parametrize("degree", [2, 3, 4, 5])
+def test_anova_kernel_fast_sparse(degree):
+    expected = np.zeros((X.shape[0], Y.shape[0]))
+    for i in range(X.shape[0]):
+        for j in range(Y.shape[0]):
+            expected[i, j] = dumb_anova(X[i], Y[j], degree=degree)
+
+    anova = pyrfm.anova_fast(csr_matrix(X), Y, degree, False)
+    assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+
+    anova = pyrfm.anova_fast(X, csr_matrix(Y), degree, False)
+    assert_array_almost_equal(expected, anova.toarray(), decimal=4)
+
+    anova = pyrfm.anova_fast(csr_matrix(X), csr_matrix(Y), degree, False)
+    assert_array_almost_equal(expected, anova.toarray(), decimal=4)
 
 def test_all_subsets_kernel():
     expected = np.zeros((X.shape[0], Y.shape[0]))

--- a/pyrfm/random_feature/tests/test_lkrf.py
+++ b/pyrfm/random_feature/tests/test_lkrf.py
@@ -7,76 +7,89 @@ from sklearn.kernel_approximation import RBFSampler
 from pyrfm import kernel_alignment, LearningKernelwithRandomFeature
 from pyrfm import (RandomKernel, RandomFourier, RandomMaclaurin,
                    OrthogonalRandomFeature)
-
+import pytest
 data = load_digits(2, True)
 X = data[0]
 X /= np.max(X)
 y = data[1]
-y = 2*y-1
+y = 2 * y - 1
 
 
 def _test_learning_kernel_with_random_feature(divergence, trans=None, rho=1):
-    print(divergence)
     if trans is None:
-        trans = RBFSampler(gamma=1, n_components=500, random_state=0)
+        trans = RBFSampler(gamma=1,  random_state=0)
+    trans.set_params(n_components=128)
     X_trans = trans.fit_transform(X)
-    score = kernel_alignment(np.dot(X_trans, X_trans.T), y)
-    lkrf = LearningKernelwithRandomFeature(trans, warm_start=True,
+    score = kernel_alignment(np.dot(X_trans, X_trans.T), y, False)
+    lkrf = LearningKernelwithRandomFeature(trans, warm_start=False,
                                            divergence=divergence,
+                                           eps_abs=1e-6, eps_rel=1e-6,
                                            max_iter=100, rho=rho)
     X_trans = lkrf.fit_transform(X, y)
-    score_lkrf = kernel_alignment(np.dot(X_trans, X_trans.T), y)
-    print(score_lkrf, score)
-
+    score_lkrf = kernel_alignment(np.dot(X_trans, X_trans.T), y, False)
     assert_greater_equal(score_lkrf, score)
     assert_almost_equal(np.sum(lkrf.importance_weights_), 1)
     assert_greater_equal(np.min(lkrf.importance_weights_), 0)
+ 
+    # weak constrain: rho = 10*rho
+    trans.fit(X)
+    lkrf = LearningKernelwithRandomFeature(trans, warm_start=False,
+                                           divergence=divergence, 
+                                           eps_abs=1e-6, eps_rel=1e-6,
+                                           max_iter=100, rho=rho*20)
+    X_trans = lkrf.fit_transform(X, y)
+    score_lkrf_weak = kernel_alignment(np.dot(X_trans, X_trans.T), y, False)
+    print(score_lkrf_weak, score_lkrf, score)
+    assert_greater_equal(score_lkrf_weak, score_lkrf)
+
     # remove bases
     n_nz = np.sum(lkrf.importance_weights_ != 0)
     print(n_nz)
- 
+
     if lkrf.remove_bases():
         X_trans_removed = lkrf.transform(X)
         assert_almost_equal(X_trans_removed.shape[1], n_nz)
         indices = np.nonzero(lkrf.importance_weights_)[0]
         assert_almost_equal(X_trans_removed, X_trans[:, indices])
+ 
+
+params =  [
+    RBFSampler(n_components=128, random_state=0),   
+    RandomFourier(n_components=128, random_state=0),   
+    RandomFourier(n_components=128, random_state=0, use_offset=True),
+    OrthogonalRandomFeature(n_components=128, random_state=0), 
+    OrthogonalRandomFeature(n_components=128, random_state=0,
+                            use_offset=True),
+    RandomMaclaurin(random_state=0),
+    RandomKernel(random_state=0)
+]
 
 
-def test_lkrf_chi2():
-    _test_learning_kernel_with_random_feature('chi2', RBFSampler(n_components=128))
-    _test_learning_kernel_with_random_feature('chi2', RBFSampler(n_components=128), rho=1)
-    _test_learning_kernel_with_random_feature('chi2', RandomMaclaurin())
-    _test_learning_kernel_with_random_feature('chi2', RandomMaclaurin(), rho=1)
-    _test_learning_kernel_with_random_feature('chi2', RandomKernel())
-    _test_learning_kernel_with_random_feature('chi2', RandomKernel(), rho=1)
-    _test_learning_kernel_with_random_feature('chi2', RandomFourier(use_offset=True))
-    _test_learning_kernel_with_random_feature('chi2', RandomFourier(use_offset=True), rho=1)
-    _test_learning_kernel_with_random_feature('chi2',
-                                               OrthogonalRandomFeature(use_offset=True))
-    _test_learning_kernel_with_random_feature('chi2',
-                                               OrthogonalRandomFeature(use_offset=True), rho=1)
-    _test_learning_kernel_with_random_feature('chi2',
-                                               OrthogonalRandomFeature(random_fourier=False))
-    _test_learning_kernel_with_random_feature('chi2',
-                                               OrthogonalRandomFeature(random_fourier=False), rho=1)
+@pytest.mark.parametrize("transformer", params)
+def test_lkrf_chi2(transformer, rho=1):
+    _test_learning_kernel_with_random_feature('chi2', transformer, rho)
+
 
 def test_lkrf_chi2_origin():
     _test_learning_kernel_with_random_feature('chi2_origin')
 
 
-def test_lkrf_kl():
-    _test_learning_kernel_with_random_feature('kl')
+@pytest.mark.parametrize("transformer", params)
+def test_lkrf_kl(transformer):
+    _test_learning_kernel_with_random_feature('kl', transformer, rho=0.01)
 
 
-def test_lkrf_reverse_kl():
-    _test_learning_kernel_with_random_feature('reverse_kl')
+@pytest.mark.parametrize("transformer", params)
+def test_lkrf_reverse_kl(transformer):
+    _test_learning_kernel_with_random_feature('reverse_kl', transformer, 0.01)
 
 
-def test_lkrf_tv():
-    _test_learning_kernel_with_random_feature('tv', rho=2)
-    _test_learning_kernel_with_random_feature('tv', rho=1)
+@pytest.mark.parametrize("transformer", params)
+def test_lkrf_tv(transformer):
+    _test_learning_kernel_with_random_feature('tv', transformer, rho=.2)
 
 
-def test_lkrf_squared():
-    _test_learning_kernel_with_random_feature('squared', rho=0.00001)
-    _test_learning_kernel_with_random_feature('squared', rho=0.0001)
+@pytest.mark.parametrize("transformer", params)
+def test_lkrf_squared(transformer):
+    _test_learning_kernel_with_random_feature('squared', transformer, 
+                                               rho=0.01)

--- a/pyrfm/random_feature/tests/test_orthogonal_random_feature.py
+++ b/pyrfm/random_feature/tests/test_orthogonal_random_feature.py
@@ -4,6 +4,8 @@ from sklearn.utils.testing import (assert_less_equal,
                                    assert_allclose_dense_sparse)
 from pyrfm import OrthogonalRandomFeature, StructuredOrthogonalRandomFeature
 from sklearn.metrics.pairwise import rbf_kernel
+import pytest
+
 
 # generate data
 rng = np.random.RandomState(0)
@@ -14,46 +16,31 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_orthogonal_random_feature():
-    for gamma, n_components in zip([10, 100], [2048, 4096]):
-        # compute exact kernel
-        kernel = rbf_kernel(X, Y, gamma)
-        # approximate kernel mapping
-        rf_transform = OrthogonalRandomFeature(n_components=n_components,
-                                               gamma=gamma,
-                                               random_state=0)
-        X_trans = rf_transform.fit_transform(X)
-        Y_trans = rf_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
-
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.01)
-        assert_less_equal(np.max(error), 0.1)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-        # for sparse matrix
-        X_trans_sp = rf_transform.transform(csr_matrix(X))
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+params = [
+    (10, 2048, True), (10, 2048, False),
+    (100, 7000, True), (100, 4096, False)
+]
 
 
-def test_orthogonal_random_feature_use_offset():
-    for gamma, n_components in zip([10, 100], [2048, 4096]):
-        # compute exact kernel
-        kernel = rbf_kernel(X, Y, gamma)
-        # approximate kernel mapping
-        rf_transform = OrthogonalRandomFeature(n_components=n_components,
-                                               gamma=gamma, use_offset=True,
-                                               random_state=0)
-        X_trans = rf_transform.fit_transform(X)
-        Y_trans = rf_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
+@pytest.mark.parametrize("gamma,n_components,use_offset", params)
+def test_orthogonal_random_feature(gamma, n_components, use_offset):
+    # compute exact kernel
+    kernel = rbf_kernel(X, Y, gamma)
+    # approximate kernel mapping
+    rf_transform = OrthogonalRandomFeature(n_components=n_components,
+                                           gamma=gamma, use_offset=use_offset,
+                                           random_state=0)
+    X_trans = rf_transform.fit_transform(X)
+    Y_trans = rf_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.01)
-        assert_less_equal(np.max(error), 0.1)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-        # for sparse matrix
-        X_trans_sp = rf_transform.transform(csr_matrix(X))
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
+    # for sparse matrix
+    X_trans_sp = rf_transform.transform(csr_matrix(X))
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
 def test_orthogonal_random_feature_for_dot():
@@ -76,27 +63,26 @@ def test_orthogonal_random_feature_for_dot():
     assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
-def test_structured_orthogonal_random_feature():
-    for gamma, n_components in zip([10, 100], [2048, 4096]):
-        # compute exact kernel
-        kernel = rbf_kernel(X, Y, gamma)
-        # approximate kernel mapping
-        rf_transform = StructuredOrthogonalRandomFeature(
-            n_components=n_components,
-            gamma=gamma,
-            random_state=0
-        )
-        X_trans = rf_transform.fit_transform(X)
-        Y_trans = rf_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
+@pytest.mark.parametrize("gamma,n_components",[(10, 2048), (100, 4096)])
+def test_structured_orthogonal_random_feature(gamma, n_components):
+    # compute exact kernel
+    kernel = rbf_kernel(X, Y, gamma)
+    # approximate kernel mapping
+    rf_transform = StructuredOrthogonalRandomFeature(
+        n_components=n_components,
+        gamma=gamma, random_state=0
+    )
+    X_trans = rf_transform.fit_transform(X)
+    Y_trans = rf_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.01)
-        assert_less_equal(np.max(error), 0.1)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-        # for sparse matrix
-        X_trans_sp = rf_transform.transform(csr_matrix(X))
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
+    # for sparse matrix
+    X_trans_sp = rf_transform.transform(csr_matrix(X))
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
 def test_structured_orthogonal_random_feature_for_dot():
@@ -104,8 +90,7 @@ def test_structured_orthogonal_random_feature_for_dot():
     kernel = np.dot(X, Y.T)
     # approximate kernel mapping
     rf_transform = StructuredOrthogonalRandomFeature(
-        n_components=64,
-        random_fourier=False,
+        n_components=64, random_fourier=False,
         random_state=0
     )
     X_trans = rf_transform.fit_transform(X)

--- a/pyrfm/random_feature/tests/test_proj_l1ball.py
+++ b/pyrfm/random_feature/tests/test_proj_l1ball.py
@@ -7,7 +7,7 @@ from pyrfm.random_feature import proj_l1ball, proj_l1ball_sort
 
 # generate data
 rng = np.random.RandomState(0)
-n_samples = 300
+n_samples = 400
 n_features = 10
 X = rng.rand(n_samples, n_features)
 Y = rng.rand(n_samples, n_features)
@@ -15,4 +15,7 @@ Y = rng.rand(n_samples, n_features)
 def test_proj_l1ball():
     for x in X:
         assert_almost_equal(proj_l1ball(x, 1), proj_l1ball_sort(x, 1))
+        assert_almost_equal(np.sum(proj_l1ball(x, 2)), 2)
+
+        assert_almost_equal(proj_l1ball(x, 5), proj_l1ball_sort(x, 5))
         assert_almost_equal(np.sum(proj_l1ball(x, 2)), 2)

--- a/pyrfm/random_feature/tests/test_random_fourier.py
+++ b/pyrfm/random_feature/tests/test_random_fourier.py
@@ -4,6 +4,7 @@ from sklearn.utils.testing import (assert_less_equal,
                                    assert_allclose_dense_sparse)
 from pyrfm import RandomFourier
 from sklearn.metrics.pairwise import rbf_kernel
+import pytest
 
 # generate data
 rng = np.random.RandomState(0)
@@ -13,8 +14,14 @@ X /= np.sum(X, axis=1, keepdims=True)
 Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
+params = [
+    (10, 2048, True), (10, 2048, False),
+    (100, 4096, True), (100, 4096, False)
+]
 
-def test_random_fourier():
+
+@pytest.mark.parametrize("gamma,n_components,use_offset", params)
+def test_random_fourier(gamma, n_components, use_offset):
     for gamma, n_components in zip([10, 100], [2048, 4096]):
         # compute exact kernel
         kernel = rbf_kernel(X, Y, gamma)
@@ -31,24 +38,4 @@ def test_random_fourier():
         assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
         # for sparse matrix
         X_trans_sp = rf_transform.transform(csr_matrix(X))
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-
-def test_random_fourier_offset():
-    for gamma, n_components in zip([10, 100], [2048, 4096]):
-        # compute exact kernel
-        kernel = rbf_kernel(X, Y, gamma)
-        # use_offset=True
-        rf_transform = RandomFourier(n_components=n_components, gamma=gamma,
-                                     use_offset=False, random_state=0)
-        X_trans = rf_transform.fit_transform(X)
-        Y_trans = rf_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.01)
-        assert_less_equal(np.max(error), 0.1)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-
-        # for sparse matrix
-        X_trans_sp = rf_transform.transform(X_sp)
         assert_allclose_dense_sparse(X_trans, X_trans_sp)

--- a/pyrfm/random_feature/tests/test_random_kernel.py
+++ b/pyrfm/random_feature/tests/test_random_kernel.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import (assert_less_equal,
                                    assert_almost_equal,
                                    assert_true)
 from pyrfm import anova, all_subsets, RandomKernel
+import pytest
+import itertools
 
 
 # generate data
@@ -17,10 +19,52 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_sparse_rademacher():
+distributions = ['rademacher', 'gaussian', 'laplace', 'uniform',
+                 'sparse_rademacher']
+degrees = [2, 3, 4, 5]
+kernels = ['anova', 'anova_cython']
+params = itertools.product(distributions, degrees, kernels)
+
+
+@pytest.mark.parametrize("dist,degree,kernel", params)
+def test_anova_kernel(dist, degree, kernel):
+    # compute exact kernel
+    gram = anova(X, Y, degree)
+    # approximate kernel mapping
+    rk_transform = RandomKernel(n_components=1000, random_state=0,
+                                kernel=kernel, degree=degree,
+                                distribution=dist, p_sparse=0.5)
+
+    X_trans = rk_transform.fit_transform(X)
+    Y_trans = rk_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
+    error =  gram - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.0001)
+    assert_less_equal(np.max(error), 0.001)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.0005)  # mean is fairly close
+
+    # sparse input
+    X_trans_sp = rk_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
+
+    # sparse output
+    if dist == "sparse_rademacher":
+        rk_transform.dense_output = False
+        X_trans_sp = rk_transform.transform(X_sp)
+        assert_true(issparse(X_trans_sp))
+        assert_allclose_dense_sparse(X_trans, X_trans_sp.toarray())
+    else:
+        rk_transform.dense_output = False
+        X_trans_sp = rk_transform.transform(X_sp)
+        assert_true(not issparse(X_trans_sp))
+        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+
+
+@pytest.mark.parametrize("p_sparse",[0.9, 0.8, 0.7, 0.6, 0.5])
+def test_sparse_rademacher(p_sparse):
     # approximate kernel mapping
     for p_sparse in [0.9, 0.8, 0.7, 0.6, 0.5]:
-        rk_transform = RandomKernel(n_components=1000, random_state=rng,
+        rk_transform = RandomKernel(n_components=1000, random_state=0,
                                     kernel='anova',
                                     distribution='sparse_rademacher',
                                     p_sparse=p_sparse)
@@ -30,99 +74,29 @@ def test_sparse_rademacher():
         assert_almost_equal(np.abs(1-nnz_actual/nnz_expected), 0, 0.1)
 
 
-def test_anova_kernel():
+
+@pytest.mark.parametrize("dist", distributions)
+def test_all_subsets_kernel(dist):
     # compute exact kernel
-    distributions = ['rademacher', 'gaussian', 'laplace', 'uniform',
-                     'sparse_rademacher']
-    for degree in range(2, 5):
-        kernel = anova(X, Y, degree)
-        for dist in distributions:
-            # approximate kernel mapping
-            rk_transform = RandomKernel(n_components=1000, random_state=rng,
-                                        kernel='anova', degree=degree,
-                                        distribution=dist, p_sparse=0.5)
-
-            X_trans = rk_transform.fit_transform(X)
-            Y_trans = rk_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.0001)
-            assert_less_equal(np.max(error), 0.001)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.0005)  # mean is fairly close
-
-            # sparse input
-            X_trans_sp = rk_transform.transform(X_sp)
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-            # sparse output
-            rk_transform.dense_output = False
-            X_trans_sp = rk_transform.transform(X_sp)
-            if issparse(X_trans_sp):
-                X_trans_sp = X_trans_sp.toarray()
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-
-def test_all_subsets_kernel():
-    # compute exact kernel
-    distributions = ['rademacher', 'gaussian', 'laplace', 'uniform',
-                     'sparse_rademacher']
     p_sparse = 0.5
     kernel = all_subsets(X, Y)
-    for dist in distributions:
-        # approximate kernel mapping
-        rk_transform = RandomKernel(n_components=4000, random_state=rng,
-                                    kernel='all_subsets',
-                                    distribution=dist, p_sparse=p_sparse)
-        X_trans = rk_transform.fit_transform(X)
-        Y_trans = rk_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
+    # approximate kernel mapping
+    rk_transform = RandomKernel(n_components=5000, random_state=0,
+                                kernel='all_subsets',
+                                distribution=dist, p_sparse=p_sparse)
+    X_trans = rk_transform.fit_transform(X)
+    Y_trans = rk_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-        error = kernel - kernel_approx
-        if dist == 'sparse_rademacher':
-            nnz = rk_transform.random_weights_.nnz
-            nnz_expect = np.prod(rk_transform.random_weights_.shape)*p_sparse
-            nnz_var = np.sqrt(nnz_expect * (1-p_sparse))
-            assert_less_equal(np.abs(nnz-nnz_expect), 3*nnz_var)
-        assert_less_equal(np.abs(np.mean(error)), 0.01)
-        assert_less_equal(np.max(error), 0.1)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
+    error = kernel - kernel_approx
+    if dist == 'sparse_rademacher':
+        nnz = rk_transform.random_weights_.nnz
+        nnz_expect = np.prod(rk_transform.random_weights_.shape)*p_sparse
+        nnz_var = np.sqrt(nnz_expect * (1-p_sparse))
+        assert_less_equal(np.abs(nnz-nnz_expect), 3*nnz_var)
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
 
-        X_trans_sp = rk_transform.transform(X_sp)
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-
-def test_anova_cython_kernel():
-    # compute exact kernel
-    distributions = ['rademacher', 'gaussian', 'laplace', 'uniform',
-                     'sparse_rademacher']
-    for degree in range(2, 5):
-        kernel = anova(X, Y, degree)
-        for dist in distributions:
-            # approximate kernel mapping
-            rk_transform = RandomKernel(n_components=1000, random_state=rng,
-                                        kernel='anova_cython', degree=degree,
-                                        distribution=dist, p_sparse=0.5)
-
-            X_trans = rk_transform.fit_transform(X)
-            Y_trans = rk_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.0001)
-            assert_less_equal(np.max(error), 0.001)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.0005)  # mean is fairly close
-
-            # sparse input
-            X_trans_sp = rk_transform.transform(X_sp)
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-            # sparse output
-            if dist == "sparse_rademacher":
-                rk_transform.dense_output = False
-                X_trans_sp = rk_transform.transform(X_sp)
-                assert_true(issparse(X_trans_sp))
-                assert_allclose_dense_sparse(X_trans, X_trans_sp.toarray())
-            else:
-                rk_transform.dense_output = False
-                X_trans_sp = rk_transform.transform(X_sp)
-                assert_true(not issparse(X_trans_sp))
-                assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = rk_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)

--- a/pyrfm/random_feature/tests/test_random_maclaurin.py
+++ b/pyrfm/random_feature/tests/test_random_maclaurin.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import assert_less_equal
 from sklearn.utils.testing import assert_allclose_dense_sparse
 from sklearn.utils.extmath import safe_sparse_dot
 from pyrfm import RandomMaclaurin
+import pytest
+import itertools
 
 
 def polynomial(X, Y, degree, bias=0):
@@ -25,68 +27,28 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_random_maclaurin_polynomial():
+params = itertools.product([0, 0.01, 0.1, 1], [2,3,4], [True, False])
+
+
+@pytest.mark.parametrize("bias,degree,h01", params)
+def test_random_maclaurin_polynomial_bias(bias, degree, h01):
     # compute exact kernel
-    for degree in range(2, 5):
-        kernel = polynomial(X, Y, degree)
-        # approximate kernel mapping
-        rm_transform = RandomMaclaurin(n_components=100, degree=degree,
-                                       random_state=rng, kernel='poly')
-        X_trans = rm_transform.fit_transform(X)
-        Y_trans = rm_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.001)
-        assert_less_equal(np.max(error), 0.01)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
+    print('bias: {} degree: {}'.format(bias, degree))
+    kernel = polynomial(X, Y, degree, bias=bias)
+    # approximate kernel mapping
+    rm_transform = RandomMaclaurin(n_components=5000, degree=degree,
+                                   random_state=rng, kernel='poly',
+                                   bias=bias, h01=h01)
+    X_trans = rm_transform.fit_transform(X)
+    Y_trans = rm_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
 
-        X_trans_sp = rm_transform.transform(X_sp)
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-
-def test_random_maclaurin_polynomial_bias():
-    # compute exact kernel
-    for bias in [0.01, 0.1, 1]:
-        for degree in range(2, 5):
-            print('bias: {} degree: {}'.format(bias, degree))
-            kernel = polynomial(X, Y, degree, bias=bias)
-            # approximate kernel mapping
-            rm_transform = RandomMaclaurin(n_components=4000, degree=degree,
-                                           random_state=rng, kernel='poly',
-                                           bias=bias)
-            X_trans = rm_transform.fit_transform(X)
-            Y_trans = rm_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.01)
-            assert_less_equal(np.max(error), 0.1)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-
-            X_trans_sp = rm_transform.transform(X_sp)
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
-
-
-def test_random_maclaurin_polynomial_bias_h01():
-    # compute exact kernel
-    for bias in [0.01, 0.1, 1]:
-
-        for degree in range(2, 5):
-            kernel = polynomial(X, Y, degree, bias=bias)
-            # approximate kernel mapping
-            print('bias: {} degree: {}'.format(bias, degree))
-            rm_transform = RandomMaclaurin(n_components=4000, degree=degree,
-                                           random_state=rng, kernel='poly',
-                                           bias=bias, h01=True)
-            X_trans = rm_transform.fit_transform(X)
-            Y_trans = rm_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.01)
-            assert_less_equal(np.max(error), 0.1)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-
-            X_trans_sp = rm_transform.transform(X_sp)
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = rm_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
 def test_random_maclaurin_exp():

--- a/pyrfm/random_feature/tests/test_scrk.py
+++ b/pyrfm/random_feature/tests/test_scrk.py
@@ -4,6 +4,7 @@ from scipy.sparse import csr_matrix
 from sklearn.utils.testing import (assert_less_equal,
                                    assert_allclose_dense_sparse)
 from pyrfm import anova, SignedCirculantRandomKernel
+import pytest
 
 
 # generate data
@@ -15,23 +16,23 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_anova_kernel():
+@pytest.mark.parametrize("degree", [2,3,4])
+def test_anova_kernel(degree):
     # compute exact kernel
-    for degree in range(2, 5):
-        kernel = anova(X, Y, degree)
-        # approximate kernel mapping
-        rk_transform = SignedCirculantRandomKernel(n_components=1000,
-                                                   random_state=rng,
-                                                   kernel='anova',
-                                                   degree=degree)
-        X_trans = rk_transform.fit_transform(X)
-        Y_trans = rk_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
+    kernel = anova(X, Y, degree)
+    # approximate kernel mapping
+    rk_transform = SignedCirculantRandomKernel(n_components=1000,
+                                                random_state=rng,
+                                                kernel='anova',
+                                                degree=degree)
+    X_trans = rk_transform.fit_transform(X)
+    Y_trans = rk_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.0001)
-        assert_less_equal(np.max(error), 0.001)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.0005)  # mean is fairly close
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.0001)
+    assert_less_equal(np.max(error), 0.001)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.0005)  # mean is fairly close
 
-        X_trans_sp = rk_transform.transform(X_sp)
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = rk_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)

--- a/pyrfm/random_feature/tests/test_signed_circulant_matrix.py
+++ b/pyrfm/random_feature/tests/test_signed_circulant_matrix.py
@@ -6,6 +6,7 @@ from pyrfm import SignedCirculantRandomMatrix
 from sklearn.metrics.pairwise import rbf_kernel
 from scipy.linalg import circulant
 from scipy.fftpack import ifft
+import pytest
 
 
 # generate data
@@ -17,38 +18,39 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_signed_circulant_matrix():
-    for gamma, n_components in zip([10, 100], [2500, 5000]):
-        # compute exact kernel
-        kernel = rbf_kernel(X, Y, gamma)
 
-        # approximate kernel mapping
-        transformer = SignedCirculantRandomMatrix(n_components=n_components, 
-                                                  gamma=gamma,
-                                                  random_state=0)
-        X_trans = transformer.fit_transform(X)
-        Y_trans = transformer.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
+@pytest.mark.parametrize("gamma,n_components", [(10, 2500), [100, 5000]])
+def test_signed_circulant_matrix(gamma, n_components):
+    # compute exact kernel
+    kernel = rbf_kernel(X, Y, gamma)
 
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.01)
-        assert_less_equal(np.max(error), 0.1)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
-        # for sparse matrix
-        X_trans_sp = transformer.transform(csr_matrix(X))
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    # approximate kernel mapping
+    transformer = SignedCirculantRandomMatrix(n_components=n_components, 
+                                                gamma=gamma,
+                                                random_state=0)
+    X_trans = transformer.fit_transform(X)
+    Y_trans = transformer.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-        # comparing naive computation
-        result = []
-        for random_weights, sign in zip(transformer.random_weights_,
-                                        transformer.random_sign_):
-            circ = circulant(ifft(random_weights).real)
-            circ *= sign.reshape(-1, 1)
-            result += [np.dot(X, circ.T)*np.sqrt(2*gamma)]
-        X_trans_naive = np.hstack(result)
-        X_trans_naive = np.cos(X_trans_naive+transformer.random_offset_)
-        X_trans_naive *= np.sqrt(2/n_components)
-        assert_allclose(X_trans, X_trans_naive)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
+    # for sparse matrix
+    X_trans_sp = transformer.transform(csr_matrix(X))
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
+
+    # comparing naive computation
+    result = []
+    for random_weights, sign in zip(transformer.random_weights_,
+                                    transformer.random_sign_):
+        circ = circulant(ifft(random_weights).real)
+        circ *= sign.reshape(-1, 1)
+        result += [np.dot(X, circ.T)*np.sqrt(2*gamma)]
+    X_trans_naive = np.hstack(result)
+    X_trans_naive = np.cos(X_trans_naive+transformer.random_offset_)
+    X_trans_naive *= np.sqrt(2/n_components)
+    assert_allclose(X_trans, X_trans_naive)
 
 
 def test_signed_circulant_random_matrix_for_dot():

--- a/pyrfm/random_feature/tests/test_subfeature_random_kernel.py
+++ b/pyrfm/random_feature/tests/test_subfeature_random_kernel.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import (assert_less_equal, assert_almost_equal,
                                    assert_allclose_dense_sparse)
 from sklearn.utils.extmath import safe_sparse_dot
 from pyrfm import anova, SubfeatureRandomKernel, RandomKernel
+import pytest
+import itertools
 
 
 # generate data
@@ -25,102 +27,56 @@ Y_sp /= np.sum(Y_sp, axis=1, keepdims=True)
 X_sp = csr_matrix(X_sp)
 Y_sp = csr_matrix(Y_sp)
 
+degrees = [2, 3, 4, 5]
+kernels = ['anova', 'anova_cython']
+params = itertools.product(degrees, kernels)
 
-def test_anova_kernel():
+
+@pytest.mark.parametrize("degree, kernel", params)
+def test_anova_kernel(degree, kernel):
     # compute exact kernel
-    distributions = ['rademacher']
-    for degree in range(2, 5):
-        kernel = anova(X, Y, degree)
-        for dist in distributions:
-            # approximate kernel mapping
-            rk_transform = SubfeatureRandomKernel(n_components=1000,
-                                              random_state=rng,
-                                              kernel='anova', degree=degree,
-                                              distribution=dist,
-                                              n_sub_features=25)
-            X_trans = rk_transform.fit_transform(X)
-            Y_trans = rk_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
+    gram = anova(X, Y, degree)
+    # approximate kernel mapping
+    rk_transform = SubfeatureRandomKernel(n_components=1000,
+                                          random_state=rng,
+                                          kernel=kernel, degree=degree,
+                                          distribution="rademacher",
+                                          n_sub_features=25)
+    X_trans = rk_transform.fit_transform(X)
+    Y_trans = rk_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.001)
-            assert_less_equal(np.max(error), 0.01)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
+    error = gram - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.001)
+    assert_less_equal(np.max(error), 0.01)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
 
 
-def test_anova_kernel_sparse():
+@pytest.mark.parametrize("degree", [2,3,4,5])
+def test_anova_kernel_sparse_subset(degree):
     # compute exact kernel
-    distributions = ['rademacher']
-    for degree in range(2, 4):
-        kernel = anova(X_sp, Y_sp, degree, True)
-        for dist in distributions:
-            # approximate kernel mapping
-            rk_transform = RandomKernel(n_components=2000*5,
-                                        random_state=rng,
-                                        kernel='anova', degree=degree,
-                                        distribution=dist)
-            X_trans = rk_transform.fit_transform(X_sp)
-            Y_trans = rk_transform.transform(Y_sp)
-            kernel_approx = safe_sparse_dot(X_trans, Y_trans.T, True)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.001)
-            assert_less_equal(np.max(error), 0.01)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
-
-
-def test_anova_kernel_sparse_sparse_rademacher():
-    # compute exact kernel
-    distributions = ['sparse_rademacher']
-    for degree in range(2, 4):
-        kernel = anova(X_sp, Y_sp, degree, True)
-        for dist in distributions:
-            # approximate kernel mapping
-            rk_transform = RandomKernel(n_components=2000*4,
-                                        random_state=rng,
-                                        kernel='anova', degree=degree,
-                                        distribution=dist, p_sparse=0.99)
-            X_trans = rk_transform.fit_transform(X_sp)
-            Y_trans = rk_transform.transform(Y_sp)
-            Y_trans_nnz = np.sum(Y_trans != 0)
-            kernel_approx = safe_sparse_dot(X_trans, Y_trans.T, True)
-            error = kernel - kernel_approx
-            print('nnz_sparse_rade {}'.format(Y_trans_nnz/np.prod(Y_trans.shape)))
-            print('abs(mean(error)) {}'.format(np.abs(np.mean(error))))
-            print('mean(abs(error)) {}'.format(np.mean(np.abs(error))))
-            print('max(abs(error)) {}'.format(np.max(np.abs(error))))
-            assert_less_equal(np.abs(np.mean(error)), 0.001)
-            assert_less_equal(np.max(error), 0.01)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
-
-
-def test_anova_kernel_sparse_subset():
-    # compute exact kernel
-    distributions = ['rademacher']
     n_components = 2000*5
     n_sub_features = 25
-    for degree in range(2, 4):
-        kernel = anova(X_sp, Y_sp, degree, True)
-        for dist in distributions:
-            # approximate kernel mapping
-            rk_transform = SubfeatureRandomKernel(n_components=n_components,
-                                                  random_state=rng,
-                                                  kernel='anova', degree=degree,
-                                                  distribution=dist,
-                                                  n_sub_features=n_sub_features)
-            X_trans = rk_transform.fit_transform(X_sp)
-            Y_trans = rk_transform.transform(Y_sp)
-            print(rk_transform.random_weights_.shape)
-            assert_almost_equal(rk_transform.random_weights_.nnz,
-                                n_components*n_sub_features)
+    gram = anova(X_sp, Y_sp, degree, True)
+    # approximate kernel mapping
+    rk_transform = SubfeatureRandomKernel(n_components=n_components,
+                                          random_state=rng,
+                                          kernel='anova', degree=degree,
+                                          distribution="rademacher",
+                                          n_sub_features=n_sub_features)
+    X_trans = rk_transform.fit_transform(X_sp)
+    Y_trans = rk_transform.transform(Y_sp)
+    assert_almost_equal(rk_transform.random_weights_.nnz,
+                        n_components*n_sub_features)
 
-            kernel_approx = safe_sparse_dot(X_trans, Y_trans.T, True)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.001)
-            assert_less_equal(np.max(error), 0.1)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
-            assert_almost_equal(n_sub_features*n_components,
-                                rk_transform.random_weights_.nnz)
-            assert_allclose_dense_sparse(
-                n_sub_features*np.ones(n_components),
-                np.array(abs(rk_transform.random_weights_).sum(axis=0))[0]
-            )
+    kernel_approx = safe_sparse_dot(X_trans, Y_trans.T, True)
+    error = gram - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.001)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
+    assert_almost_equal(n_sub_features*n_components,
+                        rk_transform.random_weights_.nnz)
+    assert_allclose_dense_sparse(
+        n_sub_features*np.ones(n_components),
+        np.array(abs(rk_transform.random_weights_).sum(axis=0))[0]
+    )

--- a/pyrfm/random_feature/tests/test_subfeature_random_maclaurin.py
+++ b/pyrfm/random_feature/tests/test_subfeature_random_maclaurin.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import assert_less_equal
 from sklearn.utils.testing import assert_allclose_dense_sparse
 from sklearn.utils.extmath import safe_sparse_dot
 from pyrfm import SubfeatureRandomMaclaurin
+import pytest
+import itertools
 
 
 def polynomial(X, Y, degree, bias=0):
@@ -25,69 +27,69 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_subfeature_random_maclaurin_polynomial():
+@pytest.mark.parametrize("degree", [2, 3, 4])
+def test_subfeature_random_maclaurin_polynomial(degree):
     # compute exact kernel
-    for degree in range(2, 5):
-        kernel = polynomial(X, Y, degree)
-        # approximate kernel mapping
-        rm_transform = SubfeatureRandomMaclaurin(n_components=500, degree=degree,
-                                                 random_state=rng, kernel='poly')
-        X_trans = rm_transform.fit_transform(X)
-        Y_trans = rm_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.001)
-        assert_less_equal(np.max(error), 0.01)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
+    kernel = polynomial(X, Y, degree)
+    # approximate kernel mapping
+    rm_transform = SubfeatureRandomMaclaurin(n_components=500, degree=degree,
+                                                random_state=rng, kernel='poly')
+    X_trans = rm_transform.fit_transform(X)
+    Y_trans = rm_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.001)
+    assert_less_equal(np.max(error), 0.01)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
 
-        X_trans_sp = rm_transform.transform(X_sp)
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = rm_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
-def test_subfeature_random_maclaurin_polynomial_bias():
+@pytest.mark.parametrize("bias, degree", 
+                         itertools.product([0.01, 0.1, 1], [2, 3, 4]))
+def test_subfeature_random_maclaurin_polynomial_bias(bias, degree):
     # compute exact kernel
-    for bias in [0.01, 0.1, 1]:
-        for degree in range(2, 5):
-            print('bias: {} degree: {}'.format(bias, degree))
-            kernel = polynomial(X, Y, degree, bias=bias)
-            # approximate kernel mapping
-            rm_transform = SubfeatureRandomMaclaurin(n_components=10000, degree=degree,
-                                                     n_sub_features=10,
-                                                     random_state=rng, kernel='poly',
-                                                     bias=bias)
-            X_trans = rm_transform.fit_transform(X)
-            Y_trans = rm_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.01)
-            assert_less_equal(np.max(error), 0.1)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
+    print('bias: {} degree: {}'.format(bias, degree))
+    kernel = polynomial(X, Y, degree, bias=bias)
+    # approximate kernel mapping
+    rm_transform = SubfeatureRandomMaclaurin(n_components=10000, degree=degree,
+                                                n_sub_features=10,
+                                                random_state=rng, kernel='poly',
+                                                bias=bias)
+    X_trans = rm_transform.fit_transform(X)
+    Y_trans = rm_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
 
-            X_trans_sp = rm_transform.transform(X_sp)
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = rm_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
-def test_subfeature_random_maclaurin_polynomial_bias_h01():
+@pytest.mark.parametrize("bias, degree", 
+                         itertools.product([0.01, 0.1, 1], [2, 3, 4]))
+def test_subfeature_random_maclaurin_polynomial_bias_h01(bias, degree):
     # compute exact kernel
-    for bias in [0.01, 0.1, 1]:
-        for degree in range(2, 5):
-            kernel = polynomial(X, Y, degree, bias=bias)
-            # approximate kernel mapping
-            print('bias: {} degree: {}'.format(bias, degree))
-            rm_transform = SubfeatureRandomMaclaurin(n_components=4000, degree=degree,
-                                                     n_sub_features=10,
-                                                     random_state=rng, kernel='poly',
-                                                     bias=bias, h01=True)
-            X_trans = rm_transform.fit_transform(X)
-            Y_trans = rm_transform.transform(Y)
-            kernel_approx = np.dot(X_trans, Y_trans.T)
-            error = kernel - kernel_approx
-            assert_less_equal(np.abs(np.mean(error)), 0.01)
-            assert_less_equal(np.max(error), 0.1)  # nothing too far off
-            assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
+    kernel = polynomial(X, Y, degree, bias=bias)
+    # approximate kernel mapping
+    print('bias: {} degree: {}'.format(bias, degree))
+    rm_transform = SubfeatureRandomMaclaurin(n_components=5000, degree=degree,
+                                             n_sub_features=10,
+                                             random_state=rng, kernel='poly',
+                                             bias=bias, h01=True)
+    X_trans = rm_transform.fit_transform(X)
+    Y_trans = rm_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.01)
+    assert_less_equal(np.max(error), 0.1)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.05)  # mean is fairly close
 
-            X_trans_sp = rm_transform.transform(X_sp)
-            assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = rm_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)
 
 
 def test_subfeature_random_maclaurin_exp():

--- a/pyrfm/random_feature/tests/test_tensor_sketch.py
+++ b/pyrfm/random_feature/tests/test_tensor_sketch.py
@@ -5,6 +5,7 @@ from sklearn.utils.testing import (assert_less_equal,
 from sklearn.utils.extmath import safe_sparse_dot
 from pyrfm import TensorSketch
 from scipy.fftpack._fftpack import drfft
+import pytest
 
 
 def polynomial(X, Y, degree):
@@ -20,21 +21,21 @@ Y /= np.sum(Y, axis=1, keepdims=True)
 X_sp = csr_matrix(X)
 
 
-def test_tensor_sketching():
+@pytest.mark.parametrize("degree", [2,3,4])
+def test_tensor_sketching(degree):
     # compute exact kernel
-    for degree in range(2, 5):
-        kernel = polynomial(X, Y, degree)
-        # approximate kernel mapping
-        ts_transform = TensorSketch(n_components=1000, degree=degree,
-                                    random_state=rng)
-        X_trans = ts_transform.fit_transform(X)
-        Y_trans = ts_transform.transform(Y)
-        kernel_approx = np.dot(X_trans, Y_trans.T)
+    kernel = polynomial(X, Y, degree)
+    # approximate kernel mapping
+    ts_transform = TensorSketch(n_components=1000, degree=degree,
+                                random_state=rng)
+    X_trans = ts_transform.fit_transform(X)
+    Y_trans = ts_transform.transform(Y)
+    kernel_approx = np.dot(X_trans, Y_trans.T)
 
-        error = kernel - kernel_approx
-        assert_less_equal(np.abs(np.mean(error)), 0.001)
-        assert_less_equal(np.max(error), 0.01)  # nothing too far off
-        assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
+    error = kernel - kernel_approx
+    assert_less_equal(np.abs(np.mean(error)), 0.001)
+    assert_less_equal(np.max(error), 0.01)  # nothing too far off
+    assert_less_equal(np.mean(error), 0.005)  # mean is fairly close
 
-        X_trans_sp = ts_transform.transform(X_sp)
-        assert_allclose_dense_sparse(X_trans, X_trans_sp)
+    X_trans_sp = ts_transform.transform(X_sp)
+    assert_allclose_dense_sparse(X_trans, X_trans_sp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 cython
 scikit-learn
-nose
+pytest


### PR DESCRIPTION
# Enhancement
- Change the framework for unit testing from nose to pytest

# Bug fixes
- anova method in kernels.py: it did output np.matrix when degree>3 and dense_output=False
- fit method of `OrthogonalRandomFeature`: it did not use its random_state for sampling chi random variables
- fit method in `LearningKernelswithRandomFeature`: it sometimes did not output a solution satisfying a constraint (fix by outputting the solution satisfying a constraint with maximum objective value in iterations)